### PR TITLE
Ability score methods

### DIFF
--- a/scripts/hero-creation-tool.js
+++ b/scripts/hero-creation-tool.js
@@ -89,17 +89,26 @@ class HeroCreationTools extends Application {
     activateListeners(html) {
 
         html.find(".abilityRandomize").click(ev => {
-            let values = [];
-
-            for (var i = 0; i < 6; i++) {
-                values.push(roll4d6b3());
-            }
-            document.getElementById("number1").value = values[0];
-            document.getElementById("number2").value = values[1];
-            document.getElementById("number3").value = values[2];
-            document.getElementById("number4").value = values[3];
-            document.getElementById("number5").value = values[4];
-            document.getElementById("number6").value = values[5];
+            rollAbilities();
+        });
+        html.find(".abilityStandard").click(ev => {
+            prepareStandardArray();
+        });
+        html.find(".abilityPointBuy").click(ev => {
+            preparePointBuy();
+        });
+        html.find(".abilityUp").click(ev => {
+            const stat = ev.currentTarget.id;
+            const i = stat.charAt(stat.length-1);
+            increaseAbility(i);
+        });
+        html.find(".abilityDown").click(ev => {
+            const stat = ev.currentTarget.id;
+            const i = stat.charAt(stat.length-1);
+            decreaseAbility(i);
+        });
+        html.find(".abilityManual").click(ev => {
+            manualAbilities();
         });
         html.find(".raceSubmit").click(ev => {
             openTab(ev, 'classDiv');
@@ -163,6 +172,163 @@ Hooks.on('renderActorSheet', (app, html, data) => {
     let titleElement = html.closest('.app').find('.configure-sheet');
     button.insertBefore(titleElement);
 });
+
+function rollAbilities() {
+    console.log(`preparing random ability array`);
+    let values = [];
+    for (var i = 0; i < 6; i++) {
+        values.push(roll4d6b3());
+    }
+    values.sort(function(a, b) {
+        return b - a;
+    });
+    toggleAbilitySelects(true);
+    toggleAbilityInputs(false);
+    togglePointBuyScore(false);
+    toggleAbilityUpDownButtons(false, false);
+    setAbilityInputs(values);
+}
+
+function prepareStandardArray() {
+    console.log(`preparing Standard Array`);
+    let values = [15, 14, 13, 12, 10, 8];
+    toggleAbilitySelects(true);
+    toggleAbilityInputs(false);
+    togglePointBuyScore(false);
+    toggleAbilityUpDownButtons(false, false);
+    setAbilityInputs(values);
+}
+
+function preparePointBuy() {
+    console.log(`preparing Point Buy`);
+    toggleAbilitySelects(false);
+    toggleAbilityInputs(false);
+    togglePointBuyScore(true);
+    toggleAbilityUpDownButtons(true, false);
+    setAbilityInputs(8);
+}
+
+function manualAbilities() {
+    console.log(`preparing manual entry`);
+    toggleAbilitySelects(false);
+    toggleAbilityInputs(true);
+    togglePointBuyScore(false);
+    toggleAbilityUpDownButtons(true, true);
+    setAbilityInputs(10);
+}
+
+function togglePointBuyScore(isPointBuy) {
+    document.getElementById("point-buy-current-score").innerHTML = "0";
+    document.getElementById("point-buy-score").hidden = !isPointBuy;
+}
+
+function changeAbility(i, up) {
+    let stat = document.getElementById("number"+i);
+    let value = stat.valueAsNumber;
+    let cost = 1;
+    if(up && value > 12)
+        cost++;
+    else if(!up && value > 13)
+        cost++;
+
+    const isPointBuy = $('#point-buy-score').is(":visible");
+
+    const currentPointsElement = document.getElementById("point-buy-current-score");
+    const currentPoints = parseInt(currentPointsElement.innerHTML);
+    const maxPoints = parseInt(document.getElementById("point-buy-max-score").innerHTML);
+   
+    const newPoints = up ? currentPoints + cost : currentPoints - cost;
+    const newValue = value + (up ? 1 : -1);
+
+    if(isPointBuy){
+        const disableUps = newPoints >= maxPoints;
+        console.log(`i: ${i} - points: ${newPoints}/${maxPoints} - disableUps: ${disableUps} - newValue: ${newValue}`)
+        for(let j=0; j<6; j++) {
+            if(j+1 != i){
+                $("#up"+(j+1)).prop( "disabled", disableUps );
+            }
+        }
+        
+        if(newValue == 15) {
+            $("#up"+i).prop("disabled", true);
+        } else if(newValue == 8) {
+            $("#down"+i).prop("disabled", true);
+        } else {
+            $("#up"+i).prop("disabled", disableUps);
+            $("#down"+i).prop("disabled", false);
+        }
+
+        // TODO do this on a notification? l18n?
+        if(newPoints > maxPoints)
+            alert("You have gone over the maximum points allowed for Point Buy");
+    } else {
+        if(newValue == 20) {
+            $("#up"+i).prop("disabled", true);
+        } else if(newValue == 0) {
+            $("#down"+i).prop("disabled", true);
+        } else {
+            $("#up"+i).prop("disabled", false);
+            $("#down"+i).prop("disabled", false);
+        }
+    }
+
+    currentPointsElement.innerHTML = newPoints;
+    stat.value = newValue;
+}
+
+function increaseAbility(i) {
+    changeAbility(i, true);
+}
+
+function decreaseAbility(i) {
+    changeAbility(i, false);
+}
+
+function setAbilityInputs(values) {
+    for(let i=0; i<6; i++) {
+        document.getElementById("number"+(i+1)).value = Array.isArray(values) ? values[i] : values;
+    }
+}
+
+function toggleAbilitySelects(enable) {
+    for(let i=0; i<6; i++) {
+        $("#stat"+(i+1)).prop("disabled", !enable);
+    }
+    if(enable) {
+        for(let i=0; i<6; i++) {
+            $("#stat"+(i+1)).val("");
+        }
+    } else {
+        $("#stat1").val("STR");
+        $("#stat2").val("DEX");
+        $("#stat3").val("CON");
+        $("#stat4").val("INT");
+        $("#stat5").val("WIS");
+        $("#stat6").val("CHA");
+    }
+}
+
+function toggleAbilityInputs(enable) {
+    for(let i=0; i<6; i++) {
+        $("#number"+(i+1)).prop("disabled", !enable);
+    }
+}
+
+function toggleAbilityUpDownButtons(show, enableDown) {
+    for(let i=0; i<6; i++) {
+        let n = i+1;
+        $("#up"+n).prop( "disabled", false );
+        $("#down"+n).prop( "disabled", !enableDown );
+        if(show){
+            $("#up"+n).show();
+            $("#down"+n).show();
+        } else {
+            $("#up"+n).hide();
+            $("#down"+n).hide();
+        }
+    }
+}
+
 function roll4d6b3() {
     const statroll1 = Math.floor(Math.random() * 6) + 1;
     const statroll2 = Math.floor(Math.random() * 6) + 1;

--- a/scripts/hero-creation-tool.js
+++ b/scripts/hero-creation-tool.js
@@ -80,7 +80,7 @@ class HeroCreationTools extends Application {
             return true;
         }
         else {
-            alert("You cannot have two of the same category.");
+            alert("You don't have all six abilities scores, check if you have some repeated or missing one.");
             return false;
         }
 
@@ -115,6 +115,7 @@ class HeroCreationTools extends Application {
         });
         html.find(".classSubmit").click(ev => {
             openTab(ev, 'abDiv');
+            rollAbilities(); // rolls a random set of scores as you move to the Abilities tab (need to find a way of doing this if you click directly there)
         });
         html.find(".abilitySubmit").click(ev => {
             /**

--- a/styles/hero-creation-tool.css
+++ b/styles/hero-creation-tool.css
@@ -41,6 +41,19 @@
   margin: 20px;
 }
 
+.horizontal-flex {
+  display: flex;
+  flex-flow: row;
+}
+
+.flex-half {
+  flex: 6
+}
+
+.flex-sixth {
+  flex: 2
+}
+
 .vertical-flex {
   display: flex;
   flex-flow: column;

--- a/styles/hero-creation-tool.css
+++ b/styles/hero-creation-tool.css
@@ -46,14 +46,6 @@
   flex-flow: row;
 }
 
-.flex-half {
-  flex: 6
-}
-
-.flex-sixth {
-  flex: 2
-}
-
 .vertical-flex {
   display: flex;
   flex-flow: column;

--- a/templates/app.html
+++ b/templates/app.html
@@ -93,78 +93,95 @@
     style="width: 100%; height: 45%;" frameborder="0"></iframe>
   <form class="flexcol prototype" autocomplete="off">
 
-    <div class ="abilityRandomize rollButton">Roll for stats</div>
-    <p style="text-align: center"> Standard Array: 15 | 14 | 13 | 12 | 10 | 8</p>
-    
-    <div class="form-group">
-      <input type="number" id="number1" placeholder="10">
-      <select name="stats" id="stat1">
-        <option value="STR" selected>Strength</option>
+    <div class="horizontal-flex">
+      <button type="button" style="text-align: center" class="abilityRandomize divButton">Roll 4d6 keep 3</button>
+      <button type="button" style="text-align: center" class="abilityStandard divButton">Standard Array</button>
+      <button type="button" style="text-align: center" class="abilityPointBuy divButton">Point Buy</button>
+      <button type="button" style="text-align: center" class="abilityManual divButton">Manual Entry</button>
+    </div>
+    <p style="text-align: center" id="point-buy-score" hidden> Point Buy Score: <span id="point-buy-current-score">0</span> / <span id="point-buy-max-score">27</span></p>
+    <div class="form-group horizontal-flex">
+      <input class="flex-sixth" type="number" id="number1" placeholder="10">
+      <button class="flex-sixth abilityUp" type="button" hidden id="up1">↑</button>
+      <button class="flex-sixth abilityDown" type="button" hidden id="down1">↓</button>
+      <select class="flex-half" name="stats" id="stat1">
+        <option value="" disabled selected>Select ability..</option>
+        <option value="STR" >Strength</option>
         <option value="DEX">Dexterity</option>
         <option value="CON">Constitution</option>
         <option value="INT">Intelligence</option>
         <option value="WIS">Wisdom</option>
-        <option value="CHAR">Charisma</option>
+        <option value="CHA">Charisma</option>
       </select>
     </div>
-
-    <div class="form-group">
-      <input type="number" id="number2" placeholder="10">
-      <select name="stats" id="stat2">
+    <div class="form-group horizontal-flex">
+      <input class="flex-sixth" type="number" id="number2" placeholder="10">
+      <button class="flex-sixth abilityUp" type="button" hidden id="up2">↑</button>
+      <button class="flex-sixth abilityDown" type="button" hidden id="down2">↓</button>
+      <select class="flex-half" name="stats" id="stat2">
+        <option value="" disabled selected>Select ability..</option>
         <option value="STR">Strength</option>
-        <option value="DEX" selected>Dexterity</option>
+        <option value="DEX" >Dexterity</option>
         <option value="CON">Constitution</option>
         <option value="INT">Intelligence</option>
         <option value="WIS">Wisdom</option>
-        <option value="CHAR">Charisma</option>
+        <option value="CHA">Charisma</option>
       </select>
     </div>
-    <div class="form-group">
-
+    <div class="form-group horizontal-flex">
       <input type="number" id="number3" placeholder="10">
-      <select name="stats" id="stat3" >
+      <button class="flex-sixth abilityUp" type="button" hidden id="up3">↑</button>
+      <button class="flex-sixth abilityDown" type="button" hidden id="down3">↓</button>
+      <select class="flex-half" name="stats" id="stat3" >
+        <option value="" disabled selected>Select ability..</option>
         <option value="STR">Strength</option>
         <option value="DEX">Dexterity</option>
-        <option value="CON" selected>Constitution</option>
+        <option value="CON">Constitution</option>
         <option value="INT">Intelligence</option>
         <option value="WIS">Wisdom</option>
-        <option value="CHAR">Charisma</option>
+        <option value="CHA">Charisma</option>
       </select>
     </div>
-
-    <div class="form-group">
+    <div class="form-group horizontal-flex">
       <input type="number" id="number4" placeholder="10">
-      <select name="stats" id="stat4" >
+      <button class="flex-sixth abilityUp" type="button" hidden id="up4">↑</button>
+      <button class="flex-sixth abilityDown" type="button" hidden id="down4">↓</button>
+      <select class="flex-half" name="stats" id="stat4" >
+        <option value="" disabled selected>Select ability..</option>
         <option value="STR">Strength</option>
         <option value="DEX">Dexterity</option>
         <option value="CON">Constitution</option>
-        <option value="INT"selected>Intelligence</option>
+        <option value="INT">Intelligence</option>
         <option value="WIS">Wisdom</option>
-        <option value="CHAR">Charisma</option>
+        <option value="CHA">Charisma</option>
       </select>
     </div>
-
-    <div class="form-group">
+    <div class="form-group horizontal-flex">
       <input type="number" id="number5" placeholder="10">
-      <select name="stats" id="stat5">
-        <option value="STR">Strength</option>
-        <option value="DEX">Dexterity</option>
-        <option value="CON">Constitution</option>
-        <option value="INT">Intelligence</option>
-        <option value="WIS"selected>Wisdom</option>
-        <option value="CHAR">Charisma</option>
-      </select>
-    </div>
-
-    <div class="form-group">
-      <input type="number" id="number6" placeholder="10">
-      <select name="stats" id="stat6">
+      <button class="flex-sixth abilityUp" type="button" hidden id="up5">↑</button>
+      <button class="flex-sixth abilityDown" type="button" hidden id="down5">↓</button>
+      <select class="flex-half" name="stats" id="stat5">
+        <option value="" disabled selected>Select ability..</option>
         <option value="STR">Strength</option>
         <option value="DEX">Dexterity</option>
         <option value="CON">Constitution</option>
         <option value="INT">Intelligence</option>
         <option value="WIS">Wisdom</option>
-        <option value="CHAR"selected>Charisma</option>
+        <option value="CHA">Charisma</option>
+      </select>
+    </div>
+    <div class="form-group horizontal-flex">
+      <input type="number" id="number6" placeholder="10">
+      <button class="flex-sixth abilityUp" type="button" hidden id="up6">↑</button>
+      <button class="flex-sixth abilityDown" type="button" hidden id="down6">↓</button>
+      <select class="flex-half" name="stats" id="stat6">
+        <option value="" disabled selected>Select ability..</option>
+        <option value="STR">Strength</option>
+        <option value="DEX">Dexterity</option>
+        <option value="CON">Constitution</option>
+        <option value="INT">Intelligence</option>
+        <option value="WIS">Wisdom</option>
+        <option value="CHA">Charisma</option>
       </select>
     </div>
     </form>


### PR DESCRIPTION
Modified Ability tab to present four options: Roll 4d6 keep 3, Standard Array, Point Buy and Manual Entry. Each option presents opinionated settings for how to set up the scores. Roll and Standard Array have the numbers fixed, and you can move the stats around. Point Buy and Manual Entry have the stat order fixed, and you can increase/decrease the stats. 

Point-buy checks against standard 27 points for now, might be customizable later.