### PR TITLE
Point buy fix plus modifiers

### DIFF
--- a/scripts/hero-creation-tool.js
+++ b/scripts/hero-creation-tool.js
@@ -28,6 +28,9 @@ class HeroCreationTools extends Application {
         /**Check that there are no repeats */
         for (var x = 0; x < listValues.length; x++) {
             for (var y = 0; y < listValues.length; y++) {
+                if(!listValues[x]) {
+                    return true;
+                }
                 if (listValues[x] == listValues[y] && x != y){
                     return true;
                 }
@@ -249,43 +252,27 @@ function togglePointBuyScore(isPointBuy) {
 
 function changeAbility(i, up) {
     let stat = document.getElementById("number"+i);
-    let value = stat.valueAsNumber;
-    let cost = 1;
-    if(up && value > 12)
-        cost++;
-    else if(!up && value > 13)
-        cost++;
-
+    const value = stat.valueAsNumber;
     const isPointBuy = $('#point-buy-score').is(":visible");
-
-    const currentPointsElement = document.getElementById("point-buy-current-score");
-    const currentPoints = parseInt(currentPointsElement.innerHTML);
-    const maxPoints = parseInt(document.getElementById("point-buy-max-score").innerHTML);
-   
-    const newPoints = up ? currentPoints + cost : currentPoints - cost;
     const newValue = value + (up ? 1 : -1);
 
-    if(isPointBuy){
-        const disableUps = newPoints >= maxPoints;
-        console.log(`i: ${i} - points: ${newPoints}/${maxPoints} - disableUps: ${disableUps} - newValue: ${newValue}`)
-        for(let j=0; j<6; j++) {
+    stat.value = newValue;
 
-            if(j+1 != i){
-                $("#up"+(j+1)).prop( "disabled", disableUps );
-            }
-        }
-        
-        if(newValue == 15) {
-            $("#up"+i).prop("disabled", true);
-            $("#down"+i).prop("disabled", false);
-        } else if(newValue == 8) {
-            $("#up"+i).prop("disabled", false);
-            $("#down"+i).prop("disabled", true);
-        } else {
-            $("#up"+i).prop("disabled", disableUps);
-            $("#down"+i).prop("disabled", false);
-        }
+    if(isPointBuy) {
+        const cost = (up && value > 12) || (!up && value > 13) ? 2 : 1;
+        const currentPointsElement = document.getElementById("point-buy-current-score");
+        const currentPoints = parseInt(currentPointsElement.innerHTML);
+        const maxPoints = parseInt(document.getElementById("point-buy-max-score").innerHTML);
+        const newPoints = up ? currentPoints + cost : currentPoints - cost;
+        currentPointsElement.innerHTML = newPoints;
 
+        for(let j=1; j<7; j++) {
+            const v = document.getElementById("number"+j).valueAsNumber;
+            const disableUp = (newPoints >= maxPoints) || (v == 15);
+            const disableDown = (v == 8);
+            $("#up"+j).prop("disabled", disableUp);
+            $("#down"+j).prop("disabled", disableDown);
+        }
         // TODO do this on a notification? l18n?
         if(newPoints > maxPoints)
             alert("You have gone over the maximum points allowed for Point Buy");
@@ -299,9 +286,6 @@ function changeAbility(i, up) {
             $("#down"+i).prop("disabled", false);
         }
     }
-
-    currentPointsElement.innerHTML = newPoints;
-    stat.value = newValue;
     updateAbilityModifiers();
 }
 

--- a/scripts/hero-creation-tool.js
+++ b/scripts/hero-creation-tool.js
@@ -88,15 +88,11 @@ class HeroCreationTools extends Application {
 
     activateListeners(html) {
 
-        html.find(".abilityRandomize").click(ev => {
-            rollAbilities();
-        });
-        html.find(".abilityStandard").click(ev => {
-            prepareStandardArray();
-        });
-        html.find(".abilityPointBuy").click(ev => {
-            preparePointBuy();
-        });
+        html.find("#ability-mod-table-toggle").click(ev => toggleAbilityScoresAndModifiersTable());
+        html.find("#abilityRandomize").click(ev => rollAbilities());
+        html.find("#abilityStandard").click(ev => prepareStandardArray());
+        html.find("#abilityPointBuy").click(ev => preparePointBuy());
+        html.find("#abilityManual").click(ev => manualAbilities());
         html.find(".abilityUp").click(ev => {
             const stat = ev.currentTarget.id;
             const i = stat.charAt(stat.length-1);
@@ -107,9 +103,7 @@ class HeroCreationTools extends Application {
             const i = stat.charAt(stat.length-1);
             decreaseAbility(i);
         });
-        html.find(".abilityManual").click(ev => {
-            manualAbilities();
-        });
+
         html.find(".raceSubmit").click(ev => {
             openTab(ev, 'classDiv');
         });
@@ -380,3 +374,11 @@ function removeSmallest(numbers) {
     const pos = numbers.indexOf(smallest);
     return numbers.slice(0, pos).concat(numbers.slice(pos + 1));
 };
+
+function toggleAbilityScoresAndModifiersTable() {
+    console.log("toggling table");
+    if($("#ability-scores-modes-table").is(":visible"))
+          $("#ability-scores-modes-table").hide();
+        else
+          $("#ability-scores-modes-table").show();
+  }

--- a/scripts/hero-creation-tool.js
+++ b/scripts/hero-creation-tool.js
@@ -208,6 +208,7 @@ function rollAbilities() {
     togglePointBuyScore(false);
     toggleAbilityUpDownButtons(false, false);
     setAbilityInputs(values);
+    updateAbilityModifiers();
 }
 
 function prepareStandardArray() {
@@ -218,6 +219,7 @@ function prepareStandardArray() {
     togglePointBuyScore(false);
     toggleAbilityUpDownButtons(false, false);
     setAbilityInputs(values);
+    updateAbilityModifiers();
 }
 
 function preparePointBuy() {
@@ -227,6 +229,7 @@ function preparePointBuy() {
     togglePointBuyScore(true);
     toggleAbilityUpDownButtons(true, false);
     setAbilityInputs(8);
+    updateAbilityModifiers();
 }
 
 function manualAbilities() {
@@ -236,6 +239,7 @@ function manualAbilities() {
     togglePointBuyScore(false);
     toggleAbilityUpDownButtons(true, true);
     setAbilityInputs(10);
+    updateAbilityModifiers();
 }
 
 function togglePointBuyScore(isPointBuy) {
@@ -265,6 +269,7 @@ function changeAbility(i, up) {
         const disableUps = newPoints >= maxPoints;
         console.log(`i: ${i} - points: ${newPoints}/${maxPoints} - disableUps: ${disableUps} - newValue: ${newValue}`)
         for(let j=0; j<6; j++) {
+
             if(j+1 != i){
                 $("#up"+(j+1)).prop( "disabled", disableUps );
             }
@@ -272,7 +277,9 @@ function changeAbility(i, up) {
         
         if(newValue == 15) {
             $("#up"+i).prop("disabled", true);
+            $("#down"+i).prop("disabled", false);
         } else if(newValue == 8) {
+            $("#up"+i).prop("disabled", false);
             $("#down"+i).prop("disabled", true);
         } else {
             $("#up"+i).prop("disabled", disableUps);
@@ -295,6 +302,7 @@ function changeAbility(i, up) {
 
     currentPointsElement.innerHTML = newPoints;
     stat.value = newValue;
+    updateAbilityModifiers();
 }
 
 function increaseAbility(i) {
@@ -376,9 +384,15 @@ function removeSmallest(numbers) {
 };
 
 function toggleAbilityScoresAndModifiersTable() {
-    console.log("toggling table");
     if($("#ability-scores-modes-table").is(":visible"))
-          $("#ability-scores-modes-table").hide();
-        else
-          $("#ability-scores-modes-table").show();
-  }
+        $("#ability-scores-modes-table").hide();
+    else
+        $("#ability-scores-modes-table").show();
+}
+
+function updateAbilityModifiers() {
+    for(let i=0; i<6; i++) {
+        const mod = Math.floor( (document.getElementById("number"+(i+1)).valueAsNumber - 10) / 2);
+        document.getElementById("mod"+(i+1)).innerHTML = mod >= 0 ? "+"+mod : mod;
+    }
+}

--- a/styles/hero-creation-tool.css
+++ b/styles/hero-creation-tool.css
@@ -199,3 +199,7 @@
 	background:linear-gradient(to bottom, #415989 5%, #2e466e 100%);
 	background-color:#415989;
 }
+
+.clickableText:hover {
+  text-decoration: underline;
+}

--- a/templates/app.html
+++ b/templates/app.html
@@ -88,94 +88,48 @@
 
 <div id="abDiv" class="tabcontent">
   <h1 style="font-family: 'Modesto Condensed';">Abilities</h1>
-  <div class="editor"><div class="editor-content" data-edit="content" style="overflow-y: visible; height: 275px; border-spacing: 10px; border-spacing: 15px; border-collapse: seperate;"><p>Each of a creature’s abilities has a score, a number that defines the magnitude of that ability. An ability score is not just a measure of innate capabilities, but also encompasses a creature’s training and competence in activities related to that ability.</p>
-    <p>A score of 10 or 11 is the normal human average, but adventurers and many monsters are a cut above average in most abilities. A score of 18 is the highest that a person usually reaches. Adventurers can have scores as high as 20, and monsters and divine beings can have scores as high as 30.</p>
-    <p>Each ability also has a modifier, derived from the score and ranging from −5 (for an ability score of 1) to +10 (for a score of 30). The Ability Scores and Modifiers table notes the ability modifiers for the range of possible ability scores, from 1 to 30.</p>
-    <table border="0" cellspacing="0"><caption>
-    <h4>Ability Scores and Modifiers</h4>
-    </caption>
-    <thead>
-    <tr>
-    <td>Score</td>
-    <td>Modifier</td>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-    <td>1</td>
-    <td>−5</td>
-    </tr>
-    <tr>
-    <td>2–3</td>
-    <td>−4</td>
-    </tr>
-    <tr>
-    <td>4–5</td>
-    <td>−3</td>
-    </tr>
-    <tr>
-    <td>6–7</td>
-    <td>−2</td>
-    </tr>
-    <tr>
-    <td>8–9</td>
-    <td>−1</td>
-    </tr>
-    <tr>
-    <td>10–11</td>
-    <td>+0</td>
-    </tr>
-    <tr>
-    <td>12–13</td>
-    <td>+1</td>
-    </tr>
-    <tr>
-    <td>14–15</td>
-    <td>+2</td>
-    </tr>
-    <tr>
-    <td>16–17</td>
-    <td>+3</td>
-    </tr>
-    <tr>
-    <td>18–19</td>
-    <td>+4</td>
-    </tr>
-    <tr>
-    <td>20–21</td>
-    <td>+5</td>
-    </tr>
-    <tr>
-    <td>22–23</td>
-    <td>+6</td>
-    </tr>
-    <tr>
-    <td>24–25</td>
-    <td>+7</td>
-    </tr>
-    <tr>
-    <td>26–27</td>
-    <td>+8</td>
-    </tr>
-    <tr>
-    <td>28–29</td>
-    <td>+9</td>
-    </tr>
-    <tr>
-    <td>30</td>
-    <td>+10</td>
-    </tr>
-    </tbody>
-    </table>
-    <p>To determine an ability modifier without consulting the table, subtract 10 from the ability score and then divide the total by 2 (round down).</p>
-    <p>Because ability modifiers affect almost every attack roll, ability check, and saving throw, ability modifiers come up in play more often than their associated scores.</p></div><a class="editor-edit"><i class="fas fa-edit"></i></a></div>
+    <div class="textarea" style="overflow: auto; overflow-y: visible; height: 275px; border-spacing: 10px; border-spacing: 15px; border-collapse: seperate;">
+      <p>Each of a creature’s abilities has a score, a number that defines the magnitude of that ability. An ability score is not just a measure of innate capabilities, but also encompasses a creature’s training and competence in activities related to that ability.</p>
+      <p>A score of 10 or 11 is the normal human average, but adventurers and many monsters are a cut above average in most abilities. A score of 18 is the highest that a person usually reaches. Adventurers can have scores as high as 20, and monsters and divine beings can have scores as high as 30.</p>
+      <p>Each ability also has a modifier, derived from the score and ranging from −5 (for an ability score of 1) to +10 (for a score of 30). The <b><span id="ability-mod-table-toggle" class="clickableText">Ability Scores and Modifiers table</span></b> notes the ability modifiers for the range of possible ability scores, from 1 to 30.</p>
+      <div id="ability-scores-modes-table" hidden>
+        <table border="0" cellspacing="0">
+          <caption>
+            <h4>Ability Scores and Modifiers</h4>
+          </caption>
+          <thead>
+            <tr><td>Score</td><td>Modifier</td></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>−5</td></tr>
+            <tr><td>2–3</td><td>−4</td></tr>
+            <tr><td>4–5</td><td>−3</td></tr>
+            <tr><td>6–7</td><td>−2</td></tr>
+            <tr><td>8–9</td><td>−1</td></tr>
+            <tr><td>10–11</td><td>+0</td></tr>
+            <tr><td>12–13</td><td>+1</td></tr>
+            <tr><td>14–15</td><td>+2</td></tr>
+            <tr><td>16–17</td><td>+3</td></tr>
+            <tr><td>18–19</td><td>+4</td></tr>
+            <tr><td>20–21</td><td>+5</td></tr>
+            <tr><td>22–23</td><td>+6</td></tr>
+            <tr><td>24–25</td><td>+7</td></tr>
+            <tr><td>26–27</td><td>+8</td></tr>
+            <tr><td>28–29</td><td>+9</td></tr>
+            <tr><td>30</td><td>+10</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>To determine an ability modifier without consulting the table, subtract 10 from the ability score and then divide the total by 2 (round down).</p>
+      <p>Because ability modifiers affect almost every attack roll, ability check, and saving throw, ability modifiers come up in play more often than their associated scores.</p>
+    </div>
   <form class="flexcol prototype" autocomplete="off">
 
     <div class="horizontal-flex">
-      <button type="button" style="text-align: center" class="abilityRandomize divButton">Roll 4d6 keep 3</button>
-      <button type="button" style="text-align: center" class="abilityStandard divButton">Standard Array</button>
-      <button type="button" style="text-align: center" class="abilityPointBuy divButton">Point Buy</button>
-      <button type="button" style="text-align: center" class="abilityManual divButton">Manual Entry</button>
+      <button type="button" style="text-align: center" id="abilityRandomize" class="divButton">Roll 4d6 keep 3</button>
+      <button type="button" style="text-align: center" id="abilityStandard" class="divButton">Standard Array</button>
+      <button type="button" style="text-align: center" id="abilityPointBuy" class="divButton">Point Buy</button>
+      <button type="button" style="text-align: center" id="abilityManual" class="divButton">Manual Entry</button>
     </div>
     <p style="text-align: center" id="point-buy-score" hidden> Point Buy Score: <span id="point-buy-current-score">0</span> / <span id="point-buy-max-score">27</span></p>
     <div class="form-group horizontal-flex">

--- a/templates/app.html
+++ b/templates/app.html
@@ -134,6 +134,7 @@
     <p style="text-align: center" id="point-buy-score" hidden> Point Buy Score: <span id="point-buy-current-score">0</span> / <span id="point-buy-max-score">27</span></p>
     <div class="form-group horizontal-flex">
       <input class="flex-sixth" type="number" id="number1" placeholder="10">
+      <span id="mod1">mod</span>
       <button class="flex-sixth abilityUp" type="button" hidden id="up1">↑</button>
       <button class="flex-sixth abilityDown" type="button" hidden id="down1">↓</button>
       <select class="flex-half" name="stats" id="stat1">
@@ -148,6 +149,7 @@
     </div>
     <div class="form-group horizontal-flex">
       <input class="flex-sixth" type="number" id="number2" placeholder="10">
+      <span id="mod2">mod</span>
       <button class="flex-sixth abilityUp" type="button" hidden id="up2">↑</button>
       <button class="flex-sixth abilityDown" type="button" hidden id="down2">↓</button>
       <select class="flex-half" name="stats" id="stat2">
@@ -162,6 +164,7 @@
     </div>
     <div class="form-group horizontal-flex">
       <input type="number" id="number3" placeholder="10">
+      <span id="mod3">mod</span>
       <button class="flex-sixth abilityUp" type="button" hidden id="up3">↑</button>
       <button class="flex-sixth abilityDown" type="button" hidden id="down3">↓</button>
       <select class="flex-half" name="stats" id="stat3" >
@@ -176,6 +179,7 @@
     </div>
     <div class="form-group horizontal-flex">
       <input type="number" id="number4" placeholder="10">
+      <span id="mod4">mod</span>
       <button class="flex-sixth abilityUp" type="button" hidden id="up4">↑</button>
       <button class="flex-sixth abilityDown" type="button" hidden id="down4">↓</button>
       <select class="flex-half" name="stats" id="stat4" >
@@ -190,6 +194,7 @@
     </div>
     <div class="form-group horizontal-flex">
       <input type="number" id="number5" placeholder="10">
+      <span id="mod5">mod</span>
       <button class="flex-sixth abilityUp" type="button" hidden id="up5">↑</button>
       <button class="flex-sixth abilityDown" type="button" hidden id="down5">↓</button>
       <select class="flex-half" name="stats" id="stat5">
@@ -204,6 +209,7 @@
     </div>
     <div class="form-group horizontal-flex">
       <input type="number" id="number6" placeholder="10">
+      <span id="mod6">mod</span>
       <button class="flex-sixth abilityUp" type="button" hidden id="up6">↑</button>
       <button class="flex-sixth abilityDown" type="button" hidden id="down6">↓</button>
       <select class="flex-half" name="stats" id="stat6">


### PR DESCRIPTION
* Fixed point-buy (had an issue where if you maxed a score at 15 it would disable the UP, but if you later lowered another stat it would unlock the previous stat allowing +15 scores)
* Style fix on the Abilities tab, changing the editor class on the text for textarea (doesn't show the Edit button on the corner on hover)
* Ability Scores and Modifiers table hidden by default, toggled on/off clicking the highlighted text on the description.
* Added modifiers column to ability scores, updated automatically as scores change on Point buy and Manual Entry (rolled and standard array should be fixed, calculated as scores as assigned).
* Added a new check when checking for duplicated abilities to account for the new empty "Select Ability.." option.
* General code refactoring of the ability scores functions and listeners.