### PR TITLE
css shiny fix + globalThis + logo image in /assets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ const SOURCE = 'src/';
 const LANG = 'lang/';
 const TEMPLATES = 'templates/';
 const CSS = 'styles/';
+const ASSETS = 'assets/';
 
 var PACKAGE = JSON.parse(fs.readFileSync('package.json'));
 function reloadPackage(cb) { PACKAGE = JSON.parse(fs.readFileSync('package.json')); cb(); }
@@ -81,6 +82,7 @@ function outputLanguages(output = null) { return () => gulp.src(LANG + GLOB).pip
 function outputTemplates(output = null) { return () => gulp.src(TEMPLATES + GLOB).pipe(gulp.dest((output || DIST) + TEMPLATES)); }
 function outputStylesCSS(output = null) { return () => gulp.src(CSS + GLOB).pipe(gulp.dest((output || DIST) + CSS)); }
 function outputMetaFiles(output = null) { return () => gulp.src(['LICENSE', 'README.md', 'CHANGELOG.md']).pipe(gulp.dest((output || DIST))); }
+function outputAssets(output = null) { return () => gulp.src(ASSETS + GLOB).pipe(gulp.dest((output || DIST) + ASSETS)); }
 
 /**
  * Copy files to module named directory and then compress that folder into a zip
@@ -120,6 +122,7 @@ exports.default = gulp.series(
 		, outputTemplates()
 		, outputStylesCSS()
 		, outputMetaFiles()
+		, outputAssets()
 	)
 );
 /**
@@ -134,6 +137,7 @@ exports.dev = gulp.series(
 		, outputTemplates(DEV_DIST())
 		, outputStylesCSS(DEV_DIST())
 		, outputMetaFiles(DEV_DIST())
+		, outputAssets(DEV_DIST())
 	)
 );
 /**
@@ -148,6 +152,7 @@ exports.zip = gulp.series(
 		, outputTemplates()
 		, outputStylesCSS()
 		, outputMetaFiles()
+		, outputAssets()
 	)
 	, compressDistribution()
 	, pdel([DIST])

--- a/lang/en.json
+++ b/lang/en.json
@@ -72,7 +72,7 @@
     "HTC.Tabs.Race.Speed": "Speed",
     "HTC.Tabs.Spells.Title": "Spells",
     "HTC.Tabs.Start.Title": "Start",
-    "HTC.Tabs.Start.Welcome": "Welcome to the Hero Creation Tool for DnD 5e!",
+    "HTC.Tabs.Start.Welcome": "Welcome to the Hero Creation Tool for DnD 5e",
     "HTC.Tabs.Start.p1": "The Hero Creation Tool is a step-by-step process for creating a character in your tabletop game. Changes are saved as you progress, but the character sheet is only updated upon completion.",
     "HTC.Tabs.Start.p2": "The Hero Creation Tool currently supports Dungeons & Dragons 5th Edition SRD material from the Players HandBook. You can add further content through the import function of the module (to be implemented?) or by creating custom modules in the creation tool.",
     "HTC.Tabs.Start.Remark": "Your Adventure Awaits! Get started by clicking Next.",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export namespace Constants {
     // Class for general global variables.
 
+    export const MODULE_NAME: string = 'hero-creation-tool';
     export const MODULE_PATH: string = 'modules/hero-creation-tool';
     export const LOG_PREFIX: string = 'Hero Creation Tool';
 }

--- a/src/generalFunctions.js
+++ b/src/generalFunctions.js
@@ -1,12 +1,10 @@
-import { Utils } from './utils.js'
-
 function getCharacter() {
-   if (!window.heroMancer) {
-      window.heroMancer = {};
-      let character = window.heroMancer;
+   if (!globalThis.heroMancer) {
+      globalThis.heroMancer = {};
+      let character = globalThis.heroMancer;
       character.resistances = [];
    }
-   return window.heroMancer
+   return globalThis.heroMancer
 }
 
 /*

--- a/src/hero-creation-tool.ts
+++ b/src/hero-creation-tool.ts
@@ -16,7 +16,7 @@ import { SpellsTab } from './tabs/spells.js'
 import { BioTab } from './tabs/bio.js'
 import { ReviewTab } from './tabs/review.js'
 
-export default class HeroCreationTools extends Application {
+export default class HeroCreationTool extends Application {
     newActor: HeroData;
     actorId: string;
     app: any;
@@ -39,12 +39,13 @@ export default class HeroCreationTools extends Application {
     }
 
     async openForActor(actorId: string) {
+        console.log(`${Constants.LOG_PREFIX} | Opening for ${actorId ? 'actor id: ' + actorId : 'new actor'}`);
         this.actorId = actorId;
         this.render(true);
     }
 
     async buildActor(newActor: HeroData) {
-        console.log(`${Constants.LOG_PREFIX} | Building actor..`);
+        console.log(`${Constants.LOG_PREFIX} | Building actor`);
         // Copies all the data in the tabs into the newActor
         BasicsTab.saveData(newActor);
         RaceTab.savaData(newActor);
@@ -60,7 +61,7 @@ export default class HeroCreationTools extends Application {
 
     activateListeners(html: JQuery) {
         super.activateListeners(html);
-        console.log(`${Constants.LOG_PREFIX} | Binding listeners..`);
+        console.log(`${Constants.LOG_PREFIX} | Binding listeners`);
 
         // listeners specific to a single tab
         BasicsTab.setListeners();
@@ -74,20 +75,20 @@ export default class HeroCreationTools extends Application {
         ReviewTab.setListeners();
 
         // set listeners for tab navigation
-        $('[data-tab]').on('click', function () {
-            Utils.openTab($(this).data('tab'));
+        $('[data-hct_tab]').on('click', function () {
+            Utils.openTab($(this).data('hct_tab'));
         })
-        $('[data-back]').on('click', function () {
-            Utils.openTab($(this).data('back'));
+        $('[data-hct_back]').on('click', function () {
+            Utils.openTab($(this).data('hct_back'));
         })
-        $('[data-next]').on('click', function () {
+        $('[data-hct_next]').on('click', function () {
             const validation = $(this).data('validation');
             if (validation) {
                 if (true) { // TODO call validation
-                    Utils.openTab($(this).data('next'));
+                    Utils.openTab($(this).data('hct_next'));
                 }
             } else {
-                Utils.openTab($(this).data('next'));
+                Utils.openTab($(this).data('hct_next'));
             }
         })
 
@@ -95,8 +96,5 @@ export default class HeroCreationTools extends Application {
             this.buildActor(this.newActor);
             this.close();
         });
-
-        // after activating all listeners, open the first tab
-        Utils.openTab('startDiv');
     };
 }

--- a/src/module-settings.ts
+++ b/src/module-settings.ts
@@ -1,0 +1,43 @@
+import { Constants } from './constants.js'
+
+export namespace ModuleSettings {
+    export function buildOptions() {
+        console.log(`${Constants.LOG_PREFIX} | Building module settings`);
+        tokenDisplayNameModeSetting();
+        tokenDisplayBarsModeSetting();
+    }
+}
+
+function tokenDisplayBarsModeSetting() {
+    game.settings.register(Constants.MODULE_NAME, "displayBarsMode", {
+        name: game.i18n.localize("HTC.Setting.TokenBarMode"),
+        scope: "world",
+        config: true,
+        choices: {
+            "0": "Never Displayed",
+            "10": "When Controlled",
+            "20": "Hover by Owner",
+            "30": "Hover by Anyone",
+            "40": "Always for Owner",
+            "50": "Always for Anyone"
+        },
+        default: "20",
+    });
+}
+
+function tokenDisplayNameModeSetting() {
+    game.settings.register(Constants.MODULE_NAME, "displayNameMode", {
+        name: game.i18n.localize("HTC.Setting.TokenNameMode"),
+        scope: "world",
+        config: true,
+        choices: {
+            "0": "Never Displayed",
+            "10": "When Controlled",
+            "20": "Hover by Owner",
+            "30": "Hover by Anyone",
+            "40": "Always for Owner",
+            "50": "Always for Anyone"
+        },
+        default: "20",
+    });
+}

--- a/src/populateList.js
+++ b/src/populateList.js
@@ -1,4 +1,3 @@
-
 /*
 Author: Alexander Sedore
 Date: 12/20/2020
@@ -7,7 +6,6 @@ Populate a selcelct dropdownlist based on id and filepath for a index json.
 Input : ID: string, object: Json Array, isIndex: boolean, defaaultName: string
 Output: N/A
 */
-import { Utils } from './utils.js'
 
 function populateList(id, object, isIndex, defaultName) {
     //initialize drop down list and add default value

--- a/src/scrapeClass.js
+++ b/src/scrapeClass.js
@@ -1,4 +1,3 @@
-import { Utils } from './utils.js'
 const fs = require('fs');
 
 function cleanSRDClasses(path) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { Constants } from './constants.js'
 export namespace Utils {
 
     export function openTab(id: string): void {
-        $('.tabcontent').hide();
+        $('.tab-body').hide();
         $(".tablinks").removeClass("active");
         $(`#${id}`).show();
     }

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,9 +1,60 @@
 /* ## General Styles */
 
+.header-hct {
+  display: flex;
+  margin: 3px;
+  align-items: center;
+  max-height: fit-content;
+}
+
+.hct-container {
+  overflow-y: hidden;
+  overflow-x: hidden;
+  height: 100%;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
 .tabs {
   display: flex;
   width: 100%;
   justify-content: space-evenly;
+}
+
+.tab-body {
+  padding: 2% 4%;
+  border-top: none;
+  width: 100%;
+  height: 92%;
+  position: relative;
+}
+
+.tab-header {
+  width: 100%;
+}
+
+.tab-content {
+  width: 100%;
+  height: 480px;
+  overflow-y: auto;
+}
+
+.tab-footer {
+  position: absolute;
+  bottom: 0;
+  padding: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+#main-logo {
+  content: url(../assets/logo.png);
+  width: 60%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+  border: none;
 }
 
 .window-content .tabs {
@@ -40,8 +91,6 @@
 /* ## Scrollable Textareas */
 
 .infoArea {
-  overflow: auto;
-  overflow-y: visible;
   border-spacing: 10px;
   border-spacing: 15px;
   border-collapse: seperate;
@@ -69,7 +118,7 @@
   border: none;
   outline: none;
   transition: all 0.3s;
-  font-size: 1.1rem;
+  font-size: 1.25rem;
   display: inline-block;
   text-align: center;
 }
@@ -118,12 +167,6 @@
   transform: scale(1.08) translateY(-5px);
   text-decoration: underline;
   text-shadow: 0 0 5px red;
-}
-
-.tabcontent {
-  display: inline-block;
-  padding: 2% 4%;
-  border-top: none;
 }
 
 /* ## Equipment */
@@ -209,27 +252,17 @@
 
 .step-button {
   width: 80px;
-  height: 30px;
-  box-shadow: inset 0px 0px 15px 3px #23395e;
-  background: linear-gradient(to bottom, #2e466e 5%, #415989 100%);
-  background-color: #2e466e;
-  border-radius: 10px;
-  border: 1px solid #1f2f47;
+  height: 32px;
+  background-color: rgba(255, 255, 240, 0.8);
+  border-radius: 3px;
+  border: 1px solid #b5b3a4;
   cursor: pointer;
-  color: #ffffff;
-  font-family: Arial;
   font-size: 15px;
-  text-decoration: none;
-  text-shadow: 0px 1px 0px #263666;
-  text-align: center;
-  padding: 5px;
-  margin: 15px;
-  float: left;
+  font-family: "Signika", sans-serif;
 }
 
 .step-button:hover {
-  background: linear-gradient(to bottom, #415989 5%, #2e466e 100%);
-  background-color: #415989;
+  background-color: rgba(245, 245, 230, 0.8);
 }
 
 /* ## Forms */
@@ -285,16 +318,18 @@
   border: none;
   outline: none;
   transition: 0.4s;
-  margin: 5px;
+  margin: 5px 0px;
 }
 
 .accordion-panel {
   padding: 0 18px;
   display: none;
-  overflow: hidden;
+  overflow-y: scroll;
   margin: 5px;
 }
 
 .centered-text {
+  width: 100%;
   text-align: center;
+  display: block;
 }

--- a/templates/app.html
+++ b/templates/app.html
@@ -1,15 +1,15 @@
-<div class="container">
+<div class="hct-container">
   <nav class="tabs">
-    <button class="tablinks" data-tab='startDiv'> {{localize 'HTC.Tabs.Start.Title'}} </button>
-    <button class="tablinks" data-tab='basicsDiv'> {{localize 'HTC.Tabs.Basics.Title'}} </button>
-    <button class="tablinks" data-tab='raceDiv'> {{localize 'HTC.Tabs.Race.Title'}} </button>
-    <button class="tablinks" data-tab='classDiv'> {{localize 'HTC.Tabs.Class.Title'}} </button>
-    <button class="tablinks" data-tab='abDiv'> {{localize 'HTC.Tabs.Abilities.Title'}} </button>
-    <button class="tablinks" data-tab='backgroundDiv'> {{localize 'HTC.Tabs.Background.Title'}} </button>
-    <button class="tablinks" data-tab='eqDiv'> {{localize 'HTC.Tabs.Equipment.Title'}} </button>
-    <button class="tablinks" data-tab='spDiv'> {{localize 'HTC.Tabs.Spells.Title'}} </button>
-    <button class="tablinks" data-tab='bioDiv'> {{localize 'HTC.Tabs.Bio.Title'}} </button>
-    <button class="tablinks" data-tab='reviewDiv'> {{localize 'HTC.Tabs.Review.Title'}} </button>
+    <button class="tablinks" data-hct_tab='startDiv'> {{localize 'HTC.Tabs.Start.Title'}} </button>
+    <button class="tablinks" data-hct_tab='basicsDiv'> {{localize 'HTC.Tabs.Basics.Title'}} </button>
+    <button class="tablinks" data-hct_tab='raceDiv'> {{localize 'HTC.Tabs.Race.Title'}} </button>
+    <button class="tablinks" data-hct_tab='classDiv'> {{localize 'HTC.Tabs.Class.Title'}} </button>
+    <button class="tablinks" data-hct_tab='abDiv'> {{localize 'HTC.Tabs.Abilities.Title'}} </button>
+    <button class="tablinks" data-hct_tab='backgroundDiv'> {{localize 'HTC.Tabs.Background.Title'}} </button>
+    <button class="tablinks" data-hct_tab='eqDiv'> {{localize 'HTC.Tabs.Equipment.Title'}} </button>
+    <button class="tablinks" data-hct_tab='spDiv'> {{localize 'HTC.Tabs.Spells.Title'}} </button>
+    <button class="tablinks" data-hct_tab='bioDiv'> {{localize 'HTC.Tabs.Bio.Title'}} </button>
+    <button class="tablinks" data-hct_tab='reviewDiv'> {{localize 'HTC.Tabs.Review.Title'}} </button>
   </nav>
 
   {{> "modules/hero-creation-tool/templates/tabs/start.html"}}

--- a/templates/tabs/abilities.html
+++ b/templates/tabs/abilities.html
@@ -1,200 +1,206 @@
-<div id="abDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Abilities.Title'}}</h1>
-    <button id='ability-desc-accordion' class="accordion-button">{{localize 'HTC.Tabs.Abilities.Buttons.Info'}}</button>
-    <div class="textarea accordion-panel" id="abilities-info">
-        <p>{{localize 'HTC.Tabs.Abilities.Info.p1'}}
-            <b><span id="ability-mod-table-toggle" class="clickableText">{{localize
-                    'HTC.Tabs.Abilities.Info.pTableTitle'}}</span></b>
-            {{localize 'HTC.Tabs.Abilities.Info.p2'}}
-        </p>
-        <div id="ability-scores-modes-table" hidden>
-            <table border="0" cellspacing="0">
-                <caption>
-                    <h4>{{localize 'HTC.Tabs.Abilities.Info.AbilityScoresTable.Title'}}</h4>
-                </caption>
-                <thead>
-                    <tr>
-                        <td>{{localize 'HTC.Tabs.Abilities.Info.AbilityScoresTable.Score'}}</td>
-                        <td>{{localize 'HTC.Tabs.Abilities.Info.AbilityScoresTable.Modifier'}}</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>1</td>
-                        <td>−5</td>
-                    </tr>
-                    <tr>
-                        <td>2–3</td>
-                        <td>−4</td>
-                    </tr>
-                    <tr>
-                        <td>4–5</td>
-                        <td>−3</td>
-                    </tr>
-                    <tr>
-                        <td>6–7</td>
-                        <td>−2</td>
-                    </tr>
-                    <tr>
-                        <td>8–9</td>
-                        <td>−1</td>
-                    </tr>
-                    <tr>
-                        <td>10–11</td>
-                        <td>+0</td>
-                    </tr>
-                    <tr>
-                        <td>12–13</td>
-                        <td>+1</td>
-                    </tr>
-                    <tr>
-                        <td>14–15</td>
-                        <td>+2</td>
-                    </tr>
-                    <tr>
-                        <td>16–17</td>
-                        <td>+3</td>
-                    </tr>
-                    <tr>
-                        <td>18–19</td>
-                        <td>+4</td>
-                    </tr>
-                    <tr>
-                        <td>20–21</td>
-                        <td>+5</td>
-                    </tr>
-                    <tr>
-                        <td>22–23</td>
-                        <td>+6</td>
-                    </tr>
-                    <tr>
-                        <td>24–25</td>
-                        <td>+7</td>
-                    </tr>
-                    <tr>
-                        <td>26–27</td>
-                        <td>+8</td>
-                    </tr>
-                    <tr>
-                        <td>28–29</td>
-                        <td>+9</td>
-                    </tr>
-                    <tr>
-                        <td>30</td>
-                        <td>+10</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <p>{{localize 'HTC.Tabs.Abilities.Info.p3'}}</p>
-    </div>
-    <form class="flexcol prototype" autocomplete="off">
+<div id="abDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Abilities.Title'}}</h1>
 
-        <div class="horizontal-flex">
-            <button type="button" class="div-button centered-text" data-mode="roll">{{localize
-                'HTC.Tabs.Abilities.Buttons.Roll'}}</button>
-            <button type="button" class="div-button centered-text" data-mode="standard">{{localize
-                'HTC.Tabs.Abilities.Buttons.StandardArray'}}</button>
-            <button type="button" class="div-button centered-text" data-mode="point-buy">{{localize
-                'HTC.Tabs.Abilities.Buttons.PointBuy'}}</button>
-            <button type="button" class="div-button centered-text" data-mode="manual">{{localize
-                'HTC.Tabs.Abilities.Buttons.ManualEntry'}}</button>
+    <main class='tab-content'>
+        <button id='ability-desc-accordion' class="accordion-button">{{localize
+            'HTC.Tabs.Abilities.Buttons.Info'}}</button>
+        <div class="textarea accordion-panel" id="abilities-info">
+            <p>{{localize 'HTC.Tabs.Abilities.Info.p1'}}
+                <b><span id="ability-mod-table-toggle" class="clickableText">{{localize
+                        'HTC.Tabs.Abilities.Info.pTableTitle'}}</span></b>
+                {{localize 'HTC.Tabs.Abilities.Info.p2'}}
+            </p>
+            <div id="ability-scores-modes-table" hidden>
+                <table border="0" cellspacing="0">
+                    <caption>
+                        <h4>{{localize 'HTC.Tabs.Abilities.Info.AbilityScoresTable.Title'}}</h4>
+                    </caption>
+                    <thead>
+                        <tr>
+                            <td>{{localize 'HTC.Tabs.Abilities.Info.AbilityScoresTable.Score'}}</td>
+                            <td>{{localize 'HTC.Tabs.Abilities.Info.AbilityScoresTable.Modifier'}}</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>−5</td>
+                        </tr>
+                        <tr>
+                            <td>2–3</td>
+                            <td>−4</td>
+                        </tr>
+                        <tr>
+                            <td>4–5</td>
+                            <td>−3</td>
+                        </tr>
+                        <tr>
+                            <td>6–7</td>
+                            <td>−2</td>
+                        </tr>
+                        <tr>
+                            <td>8–9</td>
+                            <td>−1</td>
+                        </tr>
+                        <tr>
+                            <td>10–11</td>
+                            <td>+0</td>
+                        </tr>
+                        <tr>
+                            <td>12–13</td>
+                            <td>+1</td>
+                        </tr>
+                        <tr>
+                            <td>14–15</td>
+                            <td>+2</td>
+                        </tr>
+                        <tr>
+                            <td>16–17</td>
+                            <td>+3</td>
+                        </tr>
+                        <tr>
+                            <td>18–19</td>
+                            <td>+4</td>
+                        </tr>
+                        <tr>
+                            <td>20–21</td>
+                            <td>+5</td>
+                        </tr>
+                        <tr>
+                            <td>22–23</td>
+                            <td>+6</td>
+                        </tr>
+                        <tr>
+                            <td>24–25</td>
+                            <td>+7</td>
+                        </tr>
+                        <tr>
+                            <td>26–27</td>
+                            <td>+8</td>
+                        </tr>
+                        <tr>
+                            <td>28–29</td>
+                            <td>+9</td>
+                        </tr>
+                        <tr>
+                            <td>30</td>
+                            <td>+10</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p>{{localize 'HTC.Tabs.Abilities.Info.p3'}}</p>
         </div>
-        <p class="centered-text" id="point-buy-score" hidden>{{localize 'HTC.Tabs.Abilities.PointBuyScore'}}<span
-                id="point-buy-current-score">0</span> / <span id="point-buy-max-score">27</span></p>
-        <div class="form-group horizontal-flex">
-            <input class="flex-sixth" type="number" id="number1" placeholder="10" disabled>
-            <span id="mod1" flex>+0</span>
-            <button class="flex-sixth abilityUp" type="button" hidden id="up1">↑</button>
-            <button class="flex-sixth abilityDown" type="button" hidden id="down1">↓</button>
-            <select class="flex-half" name="stats" id="stat1">
-                <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
-                <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
-                <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
-                <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
-                <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
-                <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
-                <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
-            </select>
-        </div>
-        <div class="form-group horizontal-flex">
-            <input class="flex-sixth" type="number" id="number2" placeholder="10" disabled>
-            <span id="mod2">+0</span>
-            <button class="flex-sixth abilityUp" type="button" hidden id="up2">↑</button>
-            <button class="flex-sixth abilityDown" type="button" hidden id="down2">↓</button>
-            <select class="flex-half" name="stats" id="stat2">
-                <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
-                <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
-                <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
-                <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
-                <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
-                <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
-                <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
-            </select>
-        </div>
-        <div class="form-group horizontal-flex">
-            <input class="flex-sixth" type="number" id="number3" placeholder="10" disabled>
-            <span id="mod3">+0</span>
-            <button class="flex-sixth abilityUp" type="button" hidden id="up3">↑</button>
-            <button class="flex-sixth abilityDown" type="button" hidden id="down3">↓</button>
-            <select class="flex-half" name="stats" id="stat3">
-                <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
-                <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
-                <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
-                <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
-                <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
-                <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
-                <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
-            </select>
-        </div>
-        <div class="form-group horizontal-flex">
-            <input class="flex-sixth" type="number" id="number4" placeholder="10" disabled>
-            <span id="mod4">+0</span>
-            <button class="flex-sixth abilityUp" type="button" hidden id="up4">↑</button>
-            <button class="flex-sixth abilityDown" type="button" hidden id="down4">↓</button>
-            <select class="flex-half" name="stats" id="stat4">
-                <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
-                <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
-                <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
-                <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
-                <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
-                <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
-                <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
-            </select>
-        </div>
-        <div class="form-group horizontal-flex">
-            <input class="flex-sixth" type="number" id="number5" placeholder="10" disabled>
-            <span id="mod5">+0</span>
-            <button class="flex-sixth abilityUp" type="button" hidden id="up5">↑</button>
-            <button class="flex-sixth abilityDown" type="button" hidden id="down5">↓</button>
-            <select class="flex-half" name="stats" id="stat5">
-                <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
-                <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
-                <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
-                <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
-                <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
-                <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
-                <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
-            </select>
-        </div>
-        <div class="form-group horizontal-flex">
-            <input class="flex-sixth" type="number" id="number6" placeholder="10" disabled>
-            <span id="mod6">+0</span>
-            <button class="flex-sixth abilityUp" type="button" hidden id="up6">↑</button>
-            <button class="flex-sixth abilityDown" type="button" hidden id="down6">↓</button>
-            <select class="flex-half" name="stats" id="stat6">
-                <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
-                <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
-                <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
-                <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
-                <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
-                <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
-                <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
-            </select>
-        </div>
-    </form>
+        <form class="flexcol prototype" autocomplete="off">
 
-    <button class="step-button" data-back="classDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="backgroundDiv" data-validation="_updateAbilityScores">{{localize
-        'HTC.Tabs.Next'}}</button>
+            <div class="horizontal-flex">
+                <button type="button" class="div-button centered-text" data-mode="roll">{{localize
+                    'HTC.Tabs.Abilities.Buttons.Roll'}}</button>
+                <button type="button" class="div-button centered-text" data-mode="standard">{{localize
+                    'HTC.Tabs.Abilities.Buttons.StandardArray'}}</button>
+                <button type="button" class="div-button centered-text" data-mode="point-buy">{{localize
+                    'HTC.Tabs.Abilities.Buttons.PointBuy'}}</button>
+                <button type="button" class="div-button centered-text" data-mode="manual">{{localize
+                    'HTC.Tabs.Abilities.Buttons.ManualEntry'}}</button>
+            </div>
+            <p class="centered-text" id="point-buy-score" hidden>{{localize 'HTC.Tabs.Abilities.PointBuyScore'}}<span
+                    id="point-buy-current-score">0</span> / <span id="point-buy-max-score">27</span></p>
+            <div class="form-group horizontal-flex">
+                <input class="flex-sixth" type="number" id="number1" placeholder="10" disabled>
+                <span id="mod1" flex>+0</span>
+                <button class="flex-sixth abilityUp" type="button" hidden id="up1">↑</button>
+                <button class="flex-sixth abilityDown" type="button" hidden id="down1">↓</button>
+                <select class="flex-half" name="stats" id="stat1">
+                    <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
+                    <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
+                    <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
+                    <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
+                    <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
+                    <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
+                    <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
+                </select>
+            </div>
+            <div class="form-group horizontal-flex">
+                <input class="flex-sixth" type="number" id="number2" placeholder="10" disabled>
+                <span id="mod2">+0</span>
+                <button class="flex-sixth abilityUp" type="button" hidden id="up2">↑</button>
+                <button class="flex-sixth abilityDown" type="button" hidden id="down2">↓</button>
+                <select class="flex-half" name="stats" id="stat2">
+                    <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
+                    <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
+                    <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
+                    <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
+                    <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
+                    <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
+                    <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
+                </select>
+            </div>
+            <div class="form-group horizontal-flex">
+                <input class="flex-sixth" type="number" id="number3" placeholder="10" disabled>
+                <span id="mod3">+0</span>
+                <button class="flex-sixth abilityUp" type="button" hidden id="up3">↑</button>
+                <button class="flex-sixth abilityDown" type="button" hidden id="down3">↓</button>
+                <select class="flex-half" name="stats" id="stat3">
+                    <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
+                    <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
+                    <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
+                    <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
+                    <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
+                    <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
+                    <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
+                </select>
+            </div>
+            <div class="form-group horizontal-flex">
+                <input class="flex-sixth" type="number" id="number4" placeholder="10" disabled>
+                <span id="mod4">+0</span>
+                <button class="flex-sixth abilityUp" type="button" hidden id="up4">↑</button>
+                <button class="flex-sixth abilityDown" type="button" hidden id="down4">↓</button>
+                <select class="flex-half" name="stats" id="stat4">
+                    <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
+                    <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
+                    <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
+                    <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
+                    <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
+                    <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
+                    <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
+                </select>
+            </div>
+            <div class="form-group horizontal-flex">
+                <input class="flex-sixth" type="number" id="number5" placeholder="10" disabled>
+                <span id="mod5">+0</span>
+                <button class="flex-sixth abilityUp" type="button" hidden id="up5">↑</button>
+                <button class="flex-sixth abilityDown" type="button" hidden id="down5">↓</button>
+                <select class="flex-half" name="stats" id="stat5">
+                    <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
+                    <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
+                    <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
+                    <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
+                    <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
+                    <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
+                    <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
+                </select>
+            </div>
+            <div class="form-group horizontal-flex">
+                <input class="flex-sixth" type="number" id="number6" placeholder="10" disabled>
+                <span id="mod6">+0</span>
+                <button class="flex-sixth abilityUp" type="button" hidden id="up6">↑</button>
+                <button class="flex-sixth abilityDown" type="button" hidden id="down6">↓</button>
+                <select class="flex-half" name="stats" id="stat6">
+                    <option value="" disabled selected>{{localize 'HTC.Tabs.Abilities.Select.Placeholder'}}</option>
+                    <option value="STR">{{localize 'HTC.Common.Abilities.STR'}}</option>
+                    <option value="DEX">{{localize 'HTC.Common.Abilities.DEX'}}</option>
+                    <option value="CON">{{localize 'HTC.Common.Abilities.CON'}}</option>
+                    <option value="INT">{{localize 'HTC.Common.Abilities.INT'}}</option>
+                    <option value="WIS">{{localize 'HTC.Common.Abilities.WIS'}}</option>
+                    <option value="CHA">{{localize 'HTC.Common.Abilities.CHA'}}</option>
+                </select>
+            </div>
+        </form>
+    </main>
+
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="classDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="backgroundDiv" data-validation="_updateAbilityScores">{{localize
+            'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/background.html
+++ b/templates/tabs/background.html
@@ -1,300 +1,338 @@
-<div id="backgroundDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Background.Title'}}</h1>
-    <div class="flex-separator">
-        <form class="flexcol prototype form__select--margin" action="">
-            <div class="light-pane vertical-flex">
-                <h3>{{localize 'HTC.Tabs.Background.ChooseBackground'}}</h3>
-                <select name="bg-dropdown" id="bg-dropdown">
-                    <option value="bg">this should be a list of backgrounds</option>
-                </select>
+<div id="backgroundDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Background.Title'}}</h1>
+
+    <main class='tab-content'>
+        <div class="flex-separator">
+            <form class="flexcol prototype form__select--margin" action="">
+                <div class="light-pane vertical-flex">
+                    <h3>{{localize 'HTC.Tabs.Background.ChooseBackground'}}</h3>
+                    <select name="bg-dropdown" id="bg-dropdown">
+                        <option value="bg">this should be a list of backgrounds</option>
+                    </select>
+                </div>
+
+                <h2>{{localize 'HTC.Common.SkillProficiencies'}}</h2>
+                <p id="skill-proficiencies">...</p>
+                <h2>{{localize 'HTC.Common.LanguageProficiencies'}}</h2>
+                <select name="lang1" id="lang1"></select>
+                <select name="lang2" id="lang2"></select>
+                <h2>Placeholder</h2>
+                <p id="bg-description">Description...</p>
+                <h2>{{localize 'HTC.Common.PersonalityTraits'}}</h2>
+                <select name="trait1" id="trait1"></select>
+                <select name="trait2" id="trait2"></select>
+                <h2>{{localize 'HTC.Common.Ideals'}}</h2>
+                <select name="ideal" id="ideal"></select>
+                <h2>{{localize 'HTC.Common.Bonds'}}</h2>
+                <select name="bond" id="bond"></select>
+                <h2>{{localize 'HTC.Common.Flaws'}}</h2>
+                <select name="flaw" id="flaw"></select>
+                <h2>{{localize 'HTC.Common.Equipment'}}</h2>
+                <p id="bg-equipment">Equipment...</p>
+            </form>
+
+            <div class="textarea infoArea" style="height: 750px;">
+                <p>Every story has a beginning. Your character’s background reveals where you came from, how you became
+                    an
+                    adventurer, and your place in the world. Your fighter might have been a courageous knight or a
+                    grizzled
+                    soldier.
+                    Your wizard could have been a sage or an artisan. Your rogue might have gotten by as a guild thief
+                    or
+                    commanded
+                    audiences as a jester.</p>
+                <p>Choosing a background provides you with important story cues about your character’s identity. The
+                    most
+                    important question to ask about your background is <em>what changed</em>? Why did you stop doing
+                    whatever your
+                    background describes and start adventuring? Where did you get the money to purchase your starting
+                    gear,
+                    or, if
+                    you come from a wealthy background, why don’t you have <em>more</em> money? How did you learn the
+                    skills
+                    of your
+                    class? What sets you apart from ordinary people who share your background?</p>
+                <p>The sample background presented here provides both concrete benefits (features, proficiencies, and
+                    languages)
+                    and roleplaying suggestions.</p>
+                <h3>Proficiencies</h3>
+                <p>Each background gives a character proficiency in two skills (described in <a class="entity-link"
+                        draggable="true" data-pack="dnd5e.rules" data-id="qLXNi9sr82rz60ji"><i
+                            class="fas fa-book-open"></i>
+                        Using
+                        Ability Scores</a>).</p>
+                <p>In addition, most backgrounds give a character proficiency with one or more tools (detailed in <a
+                        class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="L41AQiAKzEGSwNK5"><i
+                            class="fas fa-book-open"></i> Equipment</a>).</p>
+                <p>If a character would gain the same proficiency from two different sources, he or she can choose a
+                    different
+                    proficiency of the same kind (skill or tool) instead.</p>
+                <h3>Languages</h3>
+                <p>Some backgrounds also allow characters to learn additional languages beyond those given by race. See
+                    <a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="YokpQUkuJwUB0wpy"><i
+                            class="fas fa-book-open"></i> Languages</a>.
+                </p>
+                <h3>Equipment</h3>
+                <p>Each background provides a package of starting equipment. If you use the optional rule to spend coin
+                    on
+                    gear,
+                    you do not receive the starting equipment from your background.</p>
+                <h3>Suggested Characteristics</h3>
+                <p>A background contains suggested personal characteristics based on your background. You can pick
+                    characteristics, roll dice to determine them randomly, or use the suggestions as inspiration for
+                    characteristics
+                    of your own creation.</p>
+                <h3>Customizing a Background</h3>
+                <p>You might want to tweak some of the features of a background so it better fits your character or the
+                    campaign
+                    setting. To customize a background, you can replace one feature with any other one, choose any two
+                    skills, and
+                    choose a total of two tool proficiencies or languages from the sample backgrounds. You can either
+                    use
+                    the
+                    equipment package from your background or spend coin on gear as described in the equipment section.
+                    (If
+                    you
+                    spend coin, you can’t also take the equipment package suggested for your class.) Finally, choose two
+                    personality
+                    traits, one ideal, one bond, and one flaw. If you can’t find a feature that matches your desired
+                    background,
+                    work with your GM to create one.</p>
+                <h2>Acolyte</h2>
+                <p>You have spent your life in the service of a temple to a specific god or pantheon of gods. You act as
+                    an
+                    intermediary between the realm of the holy and the mortal world, performing sacred rites and
+                    offering
+                    sacrifices
+                    in order to conduct worshipers into the presence of the divine. You are not necessarily a
+                    cleric—performing
+                    sacred rites is not the same thing as channeling divine power.</p>
+                <p>Choose a god, a pantheon of gods, or some other quasi-divine being from among those listed in <a
+                        class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="2JNtWRo7wMq08bXn"><i
+                            class="fas fa-book-open"></i> Fantasy-Historical Pantheons</a> or those specified by your
+                    GM,
+                    and work with
+                    your GM to detail the nature of your religious service. Were you a lesser functionary in a temple,
+                    raised from
+                    childhood to assist the priests in the sacred rites? Or were you a high priest who suddenly
+                    experienced
+                    a call
+                    to serve your god in a different way? Perhaps you were the leader of a small cult outside of any
+                    established
+                    temple structure, or even an occult group that served a fiendish master that you now deny.</p>
+                <p><strong>Skill Proficiencies:</strong> Insight, Religion<br><strong>Languages: </strong>Two of your
+                    choice<br><strong>Equipment: </strong>A holy symbol (a gift to you when you entered the priesthood),
+                    a
+                    prayer
+                    book or prayer wheel, 5 sticks of incense, vestments, a set of common clothes, and a pouch
+                    containing 15
+                    gp</p>
+                <h3>Feature: Shelter of the Faithful</h3>
+                <p>As an acolyte, you command the respect of those who share your faith, and you can perform the
+                    religious
+                    ceremonies of your deity. You and your adventuring companions can expect to receive free healing and
+                    care at a
+                    temple, shrine, or other established presence of your faith, though you must provide any material
+                    components
+                    needed for spells. Those who share your religion will support you (but only you) at a modest
+                    lifestyle.
+                </p>
+                <p>You might also have ties to a specific temple dedicated to your chosen deity or pantheon, and you
+                    have a
+                    residence there. This could be the temple where you used to serve, if you remain on good terms with
+                    it,
+                    or a
+                    temple where you have found a new home. While near your temple, you can call upon the priests for
+                    assistance,
+                    provided the assistance you ask for is not hazardous and you remain in good standing with your
+                    temple.
+                </p>
+                <h3>Suggested Characteristics</h3>
+                <p>Acolytes are shaped by their experience in temples or other religious communities. Their study of the
+                    history
+                    and tenets of their faith and their relationships to temples, shrines, or hierarchies affect their
+                    mannerisms
+                    and ideals. Their flaws might be some hidden hypocrisy or heretical idea, or an ideal or bond taken
+                    to
+                    an
+                    extreme</p>
+                <table>
+                    <thead>
+                        <tr>
+                            <td>d8</td>
+                            <td>Personality Trait</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>I idolize a particular hero of my faith, and constantly refer to that person’s deeds and
+                                example.</td>
+                        </tr>
+                        <tr>
+                            <td>2</td>
+                            <td>I can find common ground between the fiercest enemies, empathizing with them and always
+                                working toward
+                                peace.</td>
+                        </tr>
+                        <tr>
+                            <td>3</td>
+                            <td>I see omens in every event and action. The gods try to speak to us, we just need to
+                                listen
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>4</td>
+                            <td>Nothing can shake my optimistic attitude.</td>
+                        </tr>
+                        <tr>
+                            <td>5</td>
+                            <td>I quote (or misquote) sacred texts and proverbs in almost every situation.</td>
+                        </tr>
+                        <tr>
+                            <td>6</td>
+                            <td>I am tolerant (or intolerant) of other faiths and respect (or condemn) the worship of
+                                other
+                                gods.</td>
+                        </tr>
+                        <tr>
+                            <td>7</td>
+                            <td>I’ve enjoyed fine food, drink, and high society among my temple’s elite. Rough living
+                                grates
+                                on me.</td>
+                        </tr>
+                        <tr>
+                            <td>8</td>
+                            <td>I’ve spent so long in the temple that I have little practical experience dealing with
+                                people
+                                in the
+                                outside world.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table>
+                    <thead>
+                        <tr>
+                            <td>d6</td>
+                            <td>Ideal</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>Tradition. The ancient traditions of worship and sacrifice must be preserved and upheld.
+                                (Lawful)</td>
+                        </tr>
+                        <tr>
+                            <td>2</td>
+                            <td>Charity. I always try to help those in need, no matter what the personal cost. (Good)
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>3</td>
+                            <td>Change. We must help bring about the changes the gods are constantly working in the
+                                world.
+                                (Chaotic)
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>4</td>
+                            <td>Power. I hope to one day rise to the top of my faith’s religious hierarchy. (Lawful)
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>5</td>
+                            <td>Faith. I trust that my deity will guide my actions. I have faith that if I work hard,
+                                things
+                                will go
+                                well. (Lawful)</td>
+                        </tr>
+                        <tr>
+                            <td>6</td>
+                            <td>Aspiration. I seek to prove myself worthy of my god’s favor by matching my actions
+                                against
+                                his or her
+                                teachings. (Any)</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table>
+                    <thead>
+                        <tr>
+                            <td>d6</td>
+                            <td>Bond</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>I would die to recover an ancient relic of my faith that was lost long ago.</td>
+                        </tr>
+                        <tr>
+                            <td>2</td>
+                            <td>I will someday get revenge on the corrupt temple hierarchy who branded me a heretic.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>3</td>
+                            <td>I owe my life to the priest who took me in when my parents died.</td>
+                        </tr>
+                        <tr>
+                            <td>4</td>
+                            <td>Everything I do is for the common people.</td>
+                        </tr>
+                        <tr>
+                            <td>5</td>
+                            <td>I will do anything to protect the temple where I served.</td>
+                        </tr>
+                        <tr>
+                            <td>6</td>
+                            <td>I seek to preserve a sacred text that my enemies consider heretical and seek to destroy.
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table>
+                    <thead>
+                        <tr>
+                            <td>d6</td>
+                            <td>Flaw</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>I judge others harshly, and myself even more severely.</td>
+                        </tr>
+                        <tr>
+                            <td>2</td>
+                            <td>I put too much trust in those who wield power within my temple’s hierarchy.</td>
+                        </tr>
+                        <tr>
+                            <td>3</td>
+                            <td>My piety sometimes leads me to blindly trust those that profess faith in my god.</td>
+                        </tr>
+                        <tr>
+                            <td>4</td>
+                            <td>I am inflexible in my thinking.</td>
+                        </tr>
+                        <tr>
+                            <td>5</td>
+                            <td>I am suspicious of strangers and expect the worst of them.</td>
+                        </tr>
+                        <tr>
+                            <td>6</td>
+                            <td>Once I pick a goal, I become obsessed with it to the detriment of everything else in my
+                                life.</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-
-            <h2>{{localize 'HTC.Common.SkillProficiencies'}}</h2>
-            <p id="skill-proficiencies">...</p>
-            <h2>{{localize 'HTC.Common.LanguageProficiencies'}}</h2>
-            <select name="lang1" id="lang1"></select>
-            <select name="lang2" id="lang2"></select>
-            <h2>Placeholder</h2>
-            <p id="bg-description">Description...</p>
-            <h2>{{localize 'HTC.Common.PersonalityTraits'}}</h2>
-            <select name="trait1" id="trait1"></select>
-            <select name="trait2" id="trait2"></select>
-            <h2>{{localize 'HTC.Common.Ideals'}}</h2>
-            <select name="ideal" id="ideal"></select>
-            <h2>{{localize 'HTC.Common.Bonds'}}</h2>
-            <select name="bond" id="bond"></select>
-            <h2>{{localize 'HTC.Common.Flaws'}}</h2>
-            <select name="flaw" id="flaw"></select>
-            <h2>{{localize 'HTC.Common.Equipment'}}</h2>
-            <p id="bg-equipment">Equipment...</p>
-        </form>
-
-        <div class="textarea infoArea" style="height: 750px;">
-            <p>Every story has a beginning. Your character’s background reveals where you came from, how you became an
-                adventurer, and your place in the world. Your fighter might have been a courageous knight or a grizzled
-                soldier.
-                Your wizard could have been a sage or an artisan. Your rogue might have gotten by as a guild thief or
-                commanded
-                audiences as a jester.</p>
-            <p>Choosing a background provides you with important story cues about your character’s identity. The most
-                important question to ask about your background is <em>what changed</em>? Why did you stop doing
-                whatever your
-                background describes and start adventuring? Where did you get the money to purchase your starting gear,
-                or, if
-                you come from a wealthy background, why don’t you have <em>more</em> money? How did you learn the skills
-                of your
-                class? What sets you apart from ordinary people who share your background?</p>
-            <p>The sample background presented here provides both concrete benefits (features, proficiencies, and
-                languages)
-                and roleplaying suggestions.</p>
-            <h3>Proficiencies</h3>
-            <p>Each background gives a character proficiency in two skills (described in <a class="entity-link"
-                    draggable="true" data-pack="dnd5e.rules" data-id="qLXNi9sr82rz60ji"><i class="fas fa-book-open"></i>
-                    Using
-                    Ability Scores</a>).</p>
-            <p>In addition, most backgrounds give a character proficiency with one or more tools (detailed in <a
-                    class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="L41AQiAKzEGSwNK5"><i
-                        class="fas fa-book-open"></i> Equipment</a>).</p>
-            <p>If a character would gain the same proficiency from two different sources, he or she can choose a
-                different
-                proficiency of the same kind (skill or tool) instead.</p>
-            <h3>Languages</h3>
-            <p>Some backgrounds also allow characters to learn additional languages beyond those given by race. See <a
-                    class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="YokpQUkuJwUB0wpy"><i
-                        class="fas fa-book-open"></i> Languages</a>.</p>
-            <h3>Equipment</h3>
-            <p>Each background provides a package of starting equipment. If you use the optional rule to spend coin on
-                gear,
-                you do not receive the starting equipment from your background.</p>
-            <h3>Suggested Characteristics</h3>
-            <p>A background contains suggested personal characteristics based on your background. You can pick
-                characteristics, roll dice to determine them randomly, or use the suggestions as inspiration for
-                characteristics
-                of your own creation.</p>
-            <h3>Customizing a Background</h3>
-            <p>You might want to tweak some of the features of a background so it better fits your character or the
-                campaign
-                setting. To customize a background, you can replace one feature with any other one, choose any two
-                skills, and
-                choose a total of two tool proficiencies or languages from the sample backgrounds. You can either use
-                the
-                equipment package from your background or spend coin on gear as described in the equipment section. (If
-                you
-                spend coin, you can’t also take the equipment package suggested for your class.) Finally, choose two
-                personality
-                traits, one ideal, one bond, and one flaw. If you can’t find a feature that matches your desired
-                background,
-                work with your GM to create one.</p>
-            <h2>Acolyte</h2>
-            <p>You have spent your life in the service of a temple to a specific god or pantheon of gods. You act as an
-                intermediary between the realm of the holy and the mortal world, performing sacred rites and offering
-                sacrifices
-                in order to conduct worshipers into the presence of the divine. You are not necessarily a
-                cleric—performing
-                sacred rites is not the same thing as channeling divine power.</p>
-            <p>Choose a god, a pantheon of gods, or some other quasi-divine being from among those listed in <a
-                    class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="2JNtWRo7wMq08bXn"><i
-                        class="fas fa-book-open"></i> Fantasy-Historical Pantheons</a> or those specified by your GM,
-                and work with
-                your GM to detail the nature of your religious service. Were you a lesser functionary in a temple,
-                raised from
-                childhood to assist the priests in the sacred rites? Or were you a high priest who suddenly experienced
-                a call
-                to serve your god in a different way? Perhaps you were the leader of a small cult outside of any
-                established
-                temple structure, or even an occult group that served a fiendish master that you now deny.</p>
-            <p><strong>Skill Proficiencies:</strong> Insight, Religion<br><strong>Languages: </strong>Two of your
-                choice<br><strong>Equipment: </strong>A holy symbol (a gift to you when you entered the priesthood), a
-                prayer
-                book or prayer wheel, 5 sticks of incense, vestments, a set of common clothes, and a pouch containing 15
-                gp</p>
-            <h3>Feature: Shelter of the Faithful</h3>
-            <p>As an acolyte, you command the respect of those who share your faith, and you can perform the religious
-                ceremonies of your deity. You and your adventuring companions can expect to receive free healing and
-                care at a
-                temple, shrine, or other established presence of your faith, though you must provide any material
-                components
-                needed for spells. Those who share your religion will support you (but only you) at a modest lifestyle.
-            </p>
-            <p>You might also have ties to a specific temple dedicated to your chosen deity or pantheon, and you have a
-                residence there. This could be the temple where you used to serve, if you remain on good terms with it,
-                or a
-                temple where you have found a new home. While near your temple, you can call upon the priests for
-                assistance,
-                provided the assistance you ask for is not hazardous and you remain in good standing with your temple.
-            </p>
-            <h3>Suggested Characteristics</h3>
-            <p>Acolytes are shaped by their experience in temples or other religious communities. Their study of the
-                history
-                and tenets of their faith and their relationships to temples, shrines, or hierarchies affect their
-                mannerisms
-                and ideals. Their flaws might be some hidden hypocrisy or heretical idea, or an ideal or bond taken to
-                an
-                extreme</p>
-            <table>
-                <thead>
-                    <tr>
-                        <td>d8</td>
-                        <td>Personality Trait</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>1</td>
-                        <td>I idolize a particular hero of my faith, and constantly refer to that person’s deeds and
-                            example.</td>
-                    </tr>
-                    <tr>
-                        <td>2</td>
-                        <td>I can find common ground between the fiercest enemies, empathizing with them and always
-                            working toward
-                            peace.</td>
-                    </tr>
-                    <tr>
-                        <td>3</td>
-                        <td>I see omens in every event and action. The gods try to speak to us, we just need to listen
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>4</td>
-                        <td>Nothing can shake my optimistic attitude.</td>
-                    </tr>
-                    <tr>
-                        <td>5</td>
-                        <td>I quote (or misquote) sacred texts and proverbs in almost every situation.</td>
-                    </tr>
-                    <tr>
-                        <td>6</td>
-                        <td>I am tolerant (or intolerant) of other faiths and respect (or condemn) the worship of other
-                            gods.</td>
-                    </tr>
-                    <tr>
-                        <td>7</td>
-                        <td>I’ve enjoyed fine food, drink, and high society among my temple’s elite. Rough living grates
-                            on me.</td>
-                    </tr>
-                    <tr>
-                        <td>8</td>
-                        <td>I’ve spent so long in the temple that I have little practical experience dealing with people
-                            in the
-                            outside world.</td>
-                    </tr>
-                </tbody>
-            </table>
-            <table>
-                <thead>
-                    <tr>
-                        <td>d6</td>
-                        <td>Ideal</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>1</td>
-                        <td>Tradition. The ancient traditions of worship and sacrifice must be preserved and upheld.
-                            (Lawful)</td>
-                    </tr>
-                    <tr>
-                        <td>2</td>
-                        <td>Charity. I always try to help those in need, no matter what the personal cost. (Good)</td>
-                    </tr>
-                    <tr>
-                        <td>3</td>
-                        <td>Change. We must help bring about the changes the gods are constantly working in the world.
-                            (Chaotic)
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>4</td>
-                        <td>Power. I hope to one day rise to the top of my faith’s religious hierarchy. (Lawful)</td>
-                    </tr>
-                    <tr>
-                        <td>5</td>
-                        <td>Faith. I trust that my deity will guide my actions. I have faith that if I work hard, things
-                            will go
-                            well. (Lawful)</td>
-                    </tr>
-                    <tr>
-                        <td>6</td>
-                        <td>Aspiration. I seek to prove myself worthy of my god’s favor by matching my actions against
-                            his or her
-                            teachings. (Any)</td>
-                    </tr>
-                </tbody>
-            </table>
-            <table>
-                <thead>
-                    <tr>
-                        <td>d6</td>
-                        <td>Bond</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>1</td>
-                        <td>I would die to recover an ancient relic of my faith that was lost long ago.</td>
-                    </tr>
-                    <tr>
-                        <td>2</td>
-                        <td>I will someday get revenge on the corrupt temple hierarchy who branded me a heretic.</td>
-                    </tr>
-                    <tr>
-                        <td>3</td>
-                        <td>I owe my life to the priest who took me in when my parents died.</td>
-                    </tr>
-                    <tr>
-                        <td>4</td>
-                        <td>Everything I do is for the common people.</td>
-                    </tr>
-                    <tr>
-                        <td>5</td>
-                        <td>I will do anything to protect the temple where I served.</td>
-                    </tr>
-                    <tr>
-                        <td>6</td>
-                        <td>I seek to preserve a sacred text that my enemies consider heretical and seek to destroy.
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <table>
-                <thead>
-                    <tr>
-                        <td>d6</td>
-                        <td>Flaw</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>1</td>
-                        <td>I judge others harshly, and myself even more severely.</td>
-                    </tr>
-                    <tr>
-                        <td>2</td>
-                        <td>I put too much trust in those who wield power within my temple’s hierarchy.</td>
-                    </tr>
-                    <tr>
-                        <td>3</td>
-                        <td>My piety sometimes leads me to blindly trust those that profess faith in my god.</td>
-                    </tr>
-                    <tr>
-                        <td>4</td>
-                        <td>I am inflexible in my thinking.</td>
-                    </tr>
-                    <tr>
-                        <td>5</td>
-                        <td>I am suspicious of strangers and expect the worst of them.</td>
-                    </tr>
-                    <tr>
-                        <td>6</td>
-                        <td>Once I pick a goal, I become obsessed with it to the detriment of everything else in my
-                            life.</td>
-                    </tr>
-                </tbody>
-            </table>
         </div>
-    </div>
+    </main>
 
-    <button class="step-button" data-back="abDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="eqDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="abDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="eqDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/basics.html
+++ b/templates/tabs/basics.html
@@ -1,35 +1,40 @@
-<div id="basicsDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Basics.Title'}}</h1>
-    <div class="form--padding">
-        <form class="flexcol prototype" autocomplete="off">
-            <div class="form-group">
-                <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.CharName'}}</label>
-                <input type="text" id="actor_name" name="name" placeholder="Name">
-            </div>
-            <div class="form-group">
-                <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.Avatar'}}</label>
-                <input type="text" id="avatar_path" placeholder="Path.." value="icons/svg/mystery-man.svg">
-                <button type="button" class="div-button file-picker centered-text" data-filepick='avatar'>
-                    {{localize 'HTC.Tabs.Basics.PickButton'}}
-                </button>
-            </div>
-            <div class="form-group">
-                <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.Token'}}</label>
-                <input type="text" id="token_path" placeholder="Path.." value="icons/svg/mystery-man.svg">
-                <button type="button" class="div-button file-picker centered-text" data-filepick='token'>
-                    {{localize 'HTC.Tabs.Basics.PickButton'}}
-                </button>
-            </div>
-            <div class="form-group">
-                <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.Preview'}}</label>
-                <div id="avatar-token-display">
-                    <img id="avatar_img" title="Avatar" src="icons/svg/mystery-man.svg" data-filepick='avatar'>
-                    <img id="token_img" title="Token" src="icons/svg/mystery-man.svg" data-filepick='token'>
-                </div>
-            </div>
-        </form>
-    </div>
+<div id="basicsDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Basics.Title'}}</h1>
 
-    <button class="step-button" data-back="startDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="raceDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    <main class='tab-content'>
+        <div class="form--padding">
+            <form class="flexcol prototype" autocomplete="off">
+                <div class="form-group">
+                    <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.CharName'}}</label>
+                    <input type="text" id="actor_name" name="name" placeholder="Name">
+                </div>
+                <div class="form-group">
+                    <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.Avatar'}}</label>
+                    <input type="text" id="avatar_path" placeholder="Path.." value="icons/svg/mystery-man.svg">
+                    <button type="button" class="div-button file-picker centered-text" data-filepick='avatar'>
+                        {{localize 'HTC.Tabs.Basics.PickButton'}}
+                    </button>
+                </div>
+                <div class="form-group">
+                    <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.Token'}}</label>
+                    <input type="text" id="token_path" placeholder="Path.." value="icons/svg/mystery-man.svg">
+                    <button type="button" class="div-button file-picker centered-text" data-filepick='token'>
+                        {{localize 'HTC.Tabs.Basics.PickButton'}}
+                    </button>
+                </div>
+                <div class="form-group">
+                    <label class="basics-top-label">{{localize 'HTC.Tabs.Basics.Preview'}}</label>
+                    <div id="avatar-token-display">
+                        <img id="avatar_img" title="Avatar" src="icons/svg/mystery-man.svg" data-filepick='avatar'>
+                        <img id="token_img" title="Token" src="icons/svg/mystery-man.svg" data-filepick='token'>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </main>
+
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="startDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="raceDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/bio.html
+++ b/templates/tabs/bio.html
@@ -1,49 +1,56 @@
-<div id="bioDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Bio.Title'}}</h1>
-    <div class="form--padding">
-        <form class="flexcol prototype" autocomplete="off">
-            <div class="form-group">
-                <label>{{localize 'HTC.Tabs.Bio.Age'}}</label>
-                <input type="text" id="character_age" name="age" placeholder="{{localize 'HTC.Tabs.Bio.Age'}}">
-            </div>
-            <div class="form-group">
-                <label>{{localize 'HTC.Tabs.Bio.Height'}}</label>
-                <input type="text" id="character_height" name="height" placeholder="{{localize 'HTC.Tabs.Bio.Height'}}">
-            </div>
-            <div class="form-group">
-                <label>{{localize 'HTC.Tabs.Bio.Weight'}}</label>
-                <input type="text" id="character_weight" name="weight" placeholder="{{localize 'HTC.Tabs.Bio.Weight'}}">
-            </div>
-            <div class="form-group">
-                <label>{{localize 'HTC.Tabs.Bio.Eyes'}}</label>
-                <div>
-                    <input type="text" id="character_eye_color" name="eye-color"
-                        placeholder="{{localize 'HTC.Tabs.Bio.Eyes'}}">
-                    <input type="color" id="character_eye_rgb" name="eye-rgb">
-                </div>
-            </div>
-            <div class="form-group">
-                <label>{{localize 'HTC.Tabs.Bio.Hair'}}</label>
-                <div>
-                    <input type="text" id="character_hair_color" name="hair-color"
-                        placeholder="{{localize 'HTC.Tabs.Bio.Hair'}}">
-                    <input type="color" id="character_hair_rgb" name="hair-rgb">
-                </div>
-            </div>
-            <div class="form-group">
-                <label>{{localize 'HTC.Tabs.Bio.Skin'}}</label>
-                <div>
-                    <input type="text" id="character_skin_color" name="skin-color"
-                        placeholder="{{localize 'HTC.Tabs.Bio.Skin'}}">
-                    <input type="color" id="character_skin_rgb" name="skin-rgb">
-                </div>
-            </div>
-            <div>
-                <textarea id="character_biography" placeholder="{{localize 'HTC.Tabs.Bio.Biography'}}"></textarea>
-            </div>
-        </form>
-    </div>
+<div id="bioDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Bio.Title'}}</h1>
 
-    <button class="step-button" data-back="spDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="reviewDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    <main class='tab-content'>
+        <div class="form--padding">
+            <form class="flexcol prototype" autocomplete="off">
+                <div class="form-group">
+                    <label>{{localize 'HTC.Tabs.Bio.Age'}}</label>
+                    <input type="text" id="character_age" name="age" placeholder="{{localize 'HTC.Tabs.Bio.Age'}}">
+                </div>
+                <div class="form-group">
+                    <label>{{localize 'HTC.Tabs.Bio.Height'}}</label>
+                    <input type="text" id="character_height" name="height"
+                        placeholder="{{localize 'HTC.Tabs.Bio.Height'}}">
+                </div>
+                <div class="form-group">
+                    <label>{{localize 'HTC.Tabs.Bio.Weight'}}</label>
+                    <input type="text" id="character_weight" name="weight"
+                        placeholder="{{localize 'HTC.Tabs.Bio.Weight'}}">
+                </div>
+                <div class="form-group">
+                    <label>{{localize 'HTC.Tabs.Bio.Eyes'}}</label>
+                    <div>
+                        <input type="text" id="character_eye_color" name="eye-color"
+                            placeholder="{{localize 'HTC.Tabs.Bio.Eyes'}}">
+                        <input type="color" id="character_eye_rgb" name="eye-rgb">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label>{{localize 'HTC.Tabs.Bio.Hair'}}</label>
+                    <div>
+                        <input type="text" id="character_hair_color" name="hair-color"
+                            placeholder="{{localize 'HTC.Tabs.Bio.Hair'}}">
+                        <input type="color" id="character_hair_rgb" name="hair-rgb">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label>{{localize 'HTC.Tabs.Bio.Skin'}}</label>
+                    <div>
+                        <input type="text" id="character_skin_color" name="skin-color"
+                            placeholder="{{localize 'HTC.Tabs.Bio.Skin'}}">
+                        <input type="color" id="character_skin_rgb" name="skin-rgb">
+                    </div>
+                </div>
+                <div>
+                    <textarea id="character_biography" placeholder="{{localize 'HTC.Tabs.Bio.Biography'}}"></textarea>
+                </div>
+            </form>
+        </div>
+    </main>
+
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="spDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="reviewDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/class.html
+++ b/templates/tabs/class.html
@@ -1,9 +1,14 @@
-<div id="classDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Class.Title'}}</h1>
-    <select id="class-dropdown" name="class">
-        <option value="class">this should be a list of classes</option>
-    </select>
+<div id="classDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Class.Title'}}</h1>
 
-    <button class="step-button" data-back="raceDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="abDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    <main class='tab-content'>
+        <select id="class-dropdown" name="class">
+            <option value="class">this should be a list of classes</option>
+        </select>
+    </main>
+
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="raceDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="abDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/equipment.html
+++ b/templates/tabs/equipment.html
@@ -1,154 +1,166 @@
-<div id="eqDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Equipment.Title'}}</h1>
-    <div class="flex-separator">
-        <div style="width: 50%; height: 100%;">
-            <form class="flexcol prototype form__select--margin" action="">
-                <div class="light-pane vertical-flex">
-                    <h3>{{localize 'HTC.Tabs.Equipment.HowToChoose'}}</h3>
-                    <select name="equip-select" id="equip-select" onChange="openSelector(event)">
-                        <option value="">{{localize 'HTC.Tabs.Equipment.Select.Default'}}</option>
-                        <option>{{localize 'HTC.Tabs.Equipment.Select.ClassEquipment'}}</option>
-                        <option>{{localize 'HTC.Tabs.Equipment.Select.StartingGold'}}</option>
-                    </select>
-                </div>
+<div id="eqDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Equipment.Title'}}</h1>
 
-                <div id="class-equip">
-                    <h1>Placeholder</h1>
-                    <form class="flexcol form__select--margin" action="">
-                        <label for="placeholder">placeholder</label> <br>
-                        <select name="placeholder" id="placeholder"></select>
-                    </form>
-                    <h2>{{localize 'HTC.Tabs.Equipment.FromBackground'}}</h2>
-                </div>
-
-                <div id="gold-equip">
-                    <h1>{{localize 'HTC.Tabs.Equipment.StartingGold.Subtitle'}}</h1>
-                    <div class="horizontal-flex">
-                        <button style="flex-shrink: 3; margin-right: 30px;">5d4x10</button>
-                        <input type="number">
+    <main class='tab-content'>
+        <div class="flex-separator">
+            <div style="width: 50%; height: 100%;">
+                <form class="flexcol prototype form__select--margin" action="">
+                    <div class="light-pane vertical-flex">
+                        <h3>{{localize 'HTC.Tabs.Equipment.HowToChoose'}}</h3>
+                        <select name="equip-select" id="equip-select" onChange="openSelector(event)">
+                            <option value="">{{localize 'HTC.Tabs.Equipment.Select.Default'}}</option>
+                            <option>{{localize 'HTC.Tabs.Equipment.Select.ClassEquipment'}}</option>
+                            <option>{{localize 'HTC.Tabs.Equipment.Select.StartingGold'}}</option>
+                        </select>
                     </div>
-                    <br>
-                    <p>{{localize 'HTC.Tabs.Equipment.StartingGold.Hint'}}</p>
-                </div>
-            </form>
-        </div>
 
-        <!-- FIXME replace this ? -->
-        <div class="textarea infoArea" style="height: 375px;">
-            <p>Common coins come in several different denominations based on the relative worth of the metal from which
-                they
-                are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper
-                piece (cp).
-            </p>
-            <p>With one gold piece, a character can buy a bedroll, 50 feet of good rope, or a goat. A skilled (but not
-                exceptional) artisan can earn one gold piece a day. The gold piece is the standard unit of measure for
-                wealth,
-                even if the coin itself is not commonly used. When merchants discuss deals that involve goods or
-                services worth
-                hundreds or thousands of gold pieces, the transactions don’t usually involve the exchange of individual
-                coins.
-                Rather, the gold piece is a standard measure of value, and the actual exchange is in gold bars, letters
-                of
-                credit, or valuable goods.</p>
-            <p>One gold piece is worth ten silver pieces, the most prevalent coin among commoners. A silver piece buys a
-                laborer’s work for half a day, a flask of lamp oil, or a night’s rest in a poor inn.</p>
-            <p>One silver piece is worth ten copper pieces, which are common among laborers and beggars. A single copper
-                piece
-                buys a candle, a torch, or a piece of chalk.</p>
-            <p>In addition, unusual coins made of other precious metals sometimes appear in treasure hoards. The
-                electrum
-                piece (ep) and the platinum piece (pp) originate from fallen empires and lost kingdoms, and they
-                sometimes
-                arouse suspicion and skepticism when used in transactions. An electrum piece is worth five silver
-                pieces, and a
-                platinum piece is worth ten gold pieces.</p>
-            <p>A standard coin weighs about a third of an ounce, so fifty coins weigh a pound.</p>
-            <table>
-                <caption>
-                    <h4>Standard Exchange Rates</h4>
-                </caption>
-                <thead>
-                    <tr>
-                        <td>Coin</td>
-                        <td>CP</td>
-                        <td>SP</td>
-                        <td>EP</td>
-                        <td>GP</td>
-                        <td>PP</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Copper (cp)</td>
-                        <td>1</td>
-                        <td>1/10</td>
-                        <td>1/50</td>
-                        <td>1/100</td>
-                        <td>1/1,000</td>
-                    </tr>
-                    <tr>
-                        <td>Silver (sp)</td>
-                        <td>10</td>
-                        <td>1</td>
-                        <td>1/5</td>
-                        <td>1/10</td>
-                        <td>1/100</td>
-                    </tr>
-                    <tr>
-                        <td>Electrum (ep)</td>
-                        <td>50</td>
-                        <td>5</td>
-                        <td>1</td>
-                        <td>1/2</td>
-                        <td>1/20</td>
-                    </tr>
-                    <tr>
-                        <td>Gold (gp)</td>
-                        <td>100</td>
-                        <td>10</td>
-                        <td>2</td>
-                        <td>1</td>
-                        <td>1/10</td>
-                    </tr>
-                    <tr>
-                        <td>Platinum (pp)</td>
-                        <td>1000</td>
-                        <td>100</td>
-                        <td>20</td>
-                        <td>10</td>
-                        <td>1</td>
-                    </tr>
-                </tbody>
-            </table>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="YUyO7WBD2DSlCBej"><i
-                        class="fas fa-book-open"></i> Selling Treasure</a></p>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="ln4KF7662eP93keD"><i
-                        class="fas fa-book-open"></i> Armor</a></p>
-            <p>&emsp;›&emsp;Light Armor</p>
-            <p>&emsp;›&emsp;Medium Armor</p>
-            <p>&emsp;›&emsp;Heavy Armor</p>
-            <p>&emsp;›&emsp;Getting Into and Out of Armor</p>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="VbMVnhcLWO4YX1V9"><i
-                        class="fas fa-book-open"></i> Weapons</a></p>
-            <p>&emsp;›&emsp;Weapon Proficiency</p>
-            <p>&emsp;›&emsp;Weapon Properties</p>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="bogWrnJqoNlBd0O8"><i
-                        class="fas fa-book-open"></i> Adventuring Gear</a></p>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="soqKcpGwvId8hQ9r"><i
-                        class="fas fa-book-open"></i> Tools</a></p>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="IAlkoC9IZnU1PzrR"><i
-                        class="fas fa-book-open"></i> Mounts and Vehicles</a></p>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="pOHY1F2F9Jf9S76B"><i
-                        class="fas fa-book-open"></i> Trade Goods</a></p>
-            <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="SlXnxASl7xZ7EjSx"><i
-                        class="fas fa-book-open"></i> Expenses</a></p>
-            <p>&emsp;›&emsp;Lifestyle Expenses</p>
-            <p>&emsp;›&emsp;Food, Drink, and Lodging</p>
-            <p>&emsp;›&emsp;Services</p>
-            <p>&emsp;›&emsp;Spellcasting Services</p>
-        </div>
-    </div>
+                    <div id="class-equip">
+                        <h1 class='tab-header'>Placeholder</h1>
+                        <form class="flexcol form__select--margin" action="">
+                            <label for="placeholder">placeholder</label> <br>
+                            <select name="placeholder" id="placeholder"></select>
+                        </form>
+                        <h2>{{localize 'HTC.Tabs.Equipment.FromBackground'}}</h2>
+                    </div>
 
-    <button class="step-button" data-back="backgroundDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="spDiv">{{localize 'HTC.Tabs.Next'}}</button>
+                    <div id="gold-equip">
+                        <h1 class='tab-header'>{{localize 'HTC.Tabs.Equipment.StartingGold.Subtitle'}}</h1>
+                        <div class="horizontal-flex">
+                            <button style="flex-shrink: 3; margin-right: 30px;">5d4x10</button>
+                            <input type="number">
+                        </div>
+                        <br>
+                        <p>{{localize 'HTC.Tabs.Equipment.StartingGold.Hint'}}</p>
+                    </div>
+                </form>
+            </div>
+
+            <!-- FIXME replace this ? -->
+            <div class="textarea infoArea" style="height: 375px;">
+                <p>Common coins come in several different denominations based on the relative worth of the metal from
+                    which
+                    they
+                    are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper
+                    piece (cp).
+                </p>
+                <p>With one gold piece, a character can buy a bedroll, 50 feet of good rope, or a goat. A skilled (but
+                    not
+                    exceptional) artisan can earn one gold piece a day. The gold piece is the standard unit of measure
+                    for
+                    wealth,
+                    even if the coin itself is not commonly used. When merchants discuss deals that involve goods or
+                    services worth
+                    hundreds or thousands of gold pieces, the transactions don’t usually involve the exchange of
+                    individual
+                    coins.
+                    Rather, the gold piece is a standard measure of value, and the actual exchange is in gold bars,
+                    letters
+                    of
+                    credit, or valuable goods.</p>
+                <p>One gold piece is worth ten silver pieces, the most prevalent coin among commoners. A silver piece
+                    buys a
+                    laborer’s work for half a day, a flask of lamp oil, or a night’s rest in a poor inn.</p>
+                <p>One silver piece is worth ten copper pieces, which are common among laborers and beggars. A single
+                    copper
+                    piece
+                    buys a candle, a torch, or a piece of chalk.</p>
+                <p>In addition, unusual coins made of other precious metals sometimes appear in treasure hoards. The
+                    electrum
+                    piece (ep) and the platinum piece (pp) originate from fallen empires and lost kingdoms, and they
+                    sometimes
+                    arouse suspicion and skepticism when used in transactions. An electrum piece is worth five silver
+                    pieces, and a
+                    platinum piece is worth ten gold pieces.</p>
+                <p>A standard coin weighs about a third of an ounce, so fifty coins weigh a pound.</p>
+                <table>
+                    <caption>
+                        <h4>Standard Exchange Rates</h4>
+                    </caption>
+                    <thead>
+                        <tr>
+                            <td>Coin</td>
+                            <td>CP</td>
+                            <td>SP</td>
+                            <td>EP</td>
+                            <td>GP</td>
+                            <td>PP</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Copper (cp)</td>
+                            <td>1</td>
+                            <td>1/10</td>
+                            <td>1/50</td>
+                            <td>1/100</td>
+                            <td>1/1,000</td>
+                        </tr>
+                        <tr>
+                            <td>Silver (sp)</td>
+                            <td>10</td>
+                            <td>1</td>
+                            <td>1/5</td>
+                            <td>1/10</td>
+                            <td>1/100</td>
+                        </tr>
+                        <tr>
+                            <td>Electrum (ep)</td>
+                            <td>50</td>
+                            <td>5</td>
+                            <td>1</td>
+                            <td>1/2</td>
+                            <td>1/20</td>
+                        </tr>
+                        <tr>
+                            <td>Gold (gp)</td>
+                            <td>100</td>
+                            <td>10</td>
+                            <td>2</td>
+                            <td>1</td>
+                            <td>1/10</td>
+                        </tr>
+                        <tr>
+                            <td>Platinum (pp)</td>
+                            <td>1000</td>
+                            <td>100</td>
+                            <td>20</td>
+                            <td>10</td>
+                            <td>1</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="YUyO7WBD2DSlCBej"><i
+                            class="fas fa-book-open"></i> Selling Treasure</a></p>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="ln4KF7662eP93keD"><i
+                            class="fas fa-book-open"></i> Armor</a></p>
+                <p>&emsp;›&emsp;Light Armor</p>
+                <p>&emsp;›&emsp;Medium Armor</p>
+                <p>&emsp;›&emsp;Heavy Armor</p>
+                <p>&emsp;›&emsp;Getting Into and Out of Armor</p>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="VbMVnhcLWO4YX1V9"><i
+                            class="fas fa-book-open"></i> Weapons</a></p>
+                <p>&emsp;›&emsp;Weapon Proficiency</p>
+                <p>&emsp;›&emsp;Weapon Properties</p>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="bogWrnJqoNlBd0O8"><i
+                            class="fas fa-book-open"></i> Adventuring Gear</a></p>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="soqKcpGwvId8hQ9r"><i
+                            class="fas fa-book-open"></i> Tools</a></p>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="IAlkoC9IZnU1PzrR"><i
+                            class="fas fa-book-open"></i> Mounts and Vehicles</a></p>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="pOHY1F2F9Jf9S76B"><i
+                            class="fas fa-book-open"></i> Trade Goods</a></p>
+                <p><a class="entity-link" draggable="true" data-pack="dnd5e.rules" data-id="SlXnxASl7xZ7EjSx"><i
+                            class="fas fa-book-open"></i> Expenses</a></p>
+                <p>&emsp;›&emsp;Lifestyle Expenses</p>
+                <p>&emsp;›&emsp;Food, Drink, and Lodging</p>
+                <p>&emsp;›&emsp;Services</p>
+                <p>&emsp;›&emsp;Spellcasting Services</p>
+            </div>
+        </div>
+    </main>
+
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="backgroundDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="spDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/race.html
+++ b/templates/tabs/race.html
@@ -1,19 +1,24 @@
-<div id="raceDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Race.Title'}}</h1>
-    <div>
-        <select id="race-dropdown" name="race-dropdown">
-            <option value="class">this should be a list of classes</option>
-        </select>
-    </div>
-    <br>
-    <h2>{{localize 'HTC.Tabs.Race.ASI'}}</h2>
-    <div id="race-ability" name="race-ability"></div>
-    <h2>{{localize 'HTC.Tabs.Race.Speed'}}</h2>
-    <div id="race-speed" name="race-speed"></div>
-    <!-- <h2>Language Proficiencies</h2> -->
-    <!-- <div id="race-language" name="race-language"></div> -->
-    <div id="race-features" name="race-features"></div>
+<div id="raceDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Race.Title'}}</h1>
 
-    <button class="step-button" data-back="basicsDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="classDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    <main class='tab-content'>
+        <div>
+            <select id="race-dropdown" name="race-dropdown">
+                <option value="class">this should be a list of classes</option>
+            </select>
+        </div>
+        <br>
+        <h2>{{localize 'HTC.Tabs.Race.ASI'}}</h2>
+        <div id="race-ability" name="race-ability"></div>
+        <h2>{{localize 'HTC.Tabs.Race.Speed'}}</h2>
+        <div id="race-speed" name="race-speed"></div>
+        <!-- <h2>Language Proficiencies</h2> -->
+        <!-- <div id="race-language" name="race-language"></div> -->
+        <div id="race-features" name="race-features"></div>
+    </main>
+
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="basicsDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="classDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/review.html
+++ b/templates/tabs/review.html
@@ -1,6 +1,7 @@
-<div id="reviewDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Review.Title'}}</h1>
-    <div class="review-container">
+<div id="reviewDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Review.Title'}}</h1>
+
+    <main class="review-container">
         <section id="review-basics" class="review-container">
             <h2>{{localize 'HTC.Tabs.Basics.Title'}}</h2>
         </section>
@@ -25,8 +26,10 @@
         <section id="review-bio" class="review-container">
             <h2>{{localize 'HTC.Tabs.Bio.Title'}}</h2>
         </section>
+    </main>
 
-        <button class="step-button" data-back="bioDiv">{{localize 'HTC.Tabs.Back'}}</button>
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="bioDiv">{{localize 'HTC.Tabs.Back'}}</button>
         <button id="finalSubmit" class="step-button">{{localize 'HTC.Tabs.Submit'}}</button>
-    </div>
+    </footer>
 </div>

--- a/templates/tabs/spells.html
+++ b/templates/tabs/spells.html
@@ -1,171 +1,202 @@
-<div id="spDiv" class="tabcontent apply-header-font">
-    <h1>{{localize 'HTC.Tabs.Spells.Title'}}</h1>
-    <div class="stat-flex-container">
-        <div class="stat-box">
-            <h3>_</h3>
-            <label for="">Strength</label>
-        </div>
-        <div class="stat-box">
-            <h3>_</h3>
-            <label for="">Dexterity</label>
-        </div>
-        <div class="stat-box">
-            <h3>_</h3>
-            <label for="">Constitution</label>
-        </div>
-        <div class="stat-box">
-            <h3>_</h3>
-            <label for="">Intelligence</label>
-        </div>
-        <div class="stat-box">
-            <h3>_</h3>
-            <label for="">Wisdom</label>
-        </div>
-        <div class="stat-box">
-            <h3>_</h3>
-            <label for="">Charisma</label>
-        </div>
-    </div>
+<div id="spDiv" class="tab-body apply-header-font">
+    <h1 class='tab-header'>{{localize 'HTC.Tabs.Spells.Title'}}</h1>
 
-    <div class="info-panel">
-        <div>
-            Hit Points:
+    <main class='tab-content'>
+        <div class="stat-flex-container">
+            <div class="stat-box">
+                <h3>_</h3>
+                <label for="">Strength</label>
+            </div>
+            <div class="stat-box">
+                <h3>_</h3>
+                <label for="">Dexterity</label>
+            </div>
+            <div class="stat-box">
+                <h3>_</h3>
+                <label for="">Constitution</label>
+            </div>
+            <div class="stat-box">
+                <h3>_</h3>
+                <label for="">Intelligence</label>
+            </div>
+            <div class="stat-box">
+                <h3>_</h3>
+                <label for="">Wisdom</label>
+            </div>
+            <div class="stat-box">
+                <h3>_</h3>
+                <label for="">Charisma</label>
+            </div>
         </div>
-        <div>
-            Suggest Abilites:
-        </div>
-        <div>
-            Class Spellcasting Ability:
-        </div>
-    </div>
 
-    <div class="flex-separator">
-        <div style="width: 50%">
-            <form class="flexcol prototype form__select--margin" action="">
-                <label for="CLASS">CLASS PLACEHOLDER</label>
-                <select name="" id=""></select>
-                <select name="" id=""></select>
-                <select name="" id=""></select>
-                <select name="" id=""></select>
-                <label for="CLASS">CLASS PLACEHOLDER</label>
-                <select name="" id=""></select>
-                <select name="" id=""></select>
-                <select name="" id=""></select>
-                <select name="" id=""></select>
-            </form>
+        <div class="info-panel">
+            <div>
+                Hit Points:
+            </div>
+            <div>
+                Suggest Abilites:
+            </div>
+            <div>
+                Class Spellcasting Ability:
+            </div>
         </div>
-        <div class="textarea infoArea" style="height: 375px;">
-            <p>A spell is a discrete magical effect, a single shaping of the magical energies that suffuse the
-                multiverse into
-                a specific, limited expression. In casting a spell, a character carefully plucks at the invisible
-                strands of raw
-                magic suffusing the world, pins them in place in a particular pattern, sets them vibrating in a specific
-                way,
-                and then releases them to unleash the desired effect—in most cases, all in the span of seconds.</p>
-            <p>Spells can be versatile tools, weapons, or protective wards. They can deal damage or undo it, impose or
-                remove
-                conditions (see <a class="entity-link" draggable="true" data-pack="dnd5e.rules"
-                    data-id="lrgT2KMBGTgZD4sA"><i class="fas fa-book-open"></i> Appendix PH-A</a>), drain life energy
-                away, and restore life to the dead.</p>
-            <p>Uncounted thousands of spells have been created over the course of the multiverse’s history, and many of
-                them
-                are long forgotten. Some might yet lie recorded in crumbling spellbooks hidden in ancient ruins or
-                trapped in
-                the minds of dead gods. Or they might someday be reinvented by a character who has amassed enough power
-                and
-                wisdom to do so.</p>
-            <h2>Spell Level</h2>
-            <p>Every spell has a level from 0 to 9. A spell’s level is a general indicator of how powerful it is, with
-                the
-                lowly (but still impressive) <a class="entity-link" draggable="true" data-pack="dnd5e.spells"
-                    data-id="41JIhpDyM9Anm7cs"><i class="fas fa-suitcase"></i> Magic Missile</a> at 1st level and the
-                earth-shaking <a class="entity-link" draggable="true" data-pack="dnd5e.spells"
-                    data-id="3okM6Gn63zzEULkz"><i class="fas fa-suitcase"></i> Wish</a> at 9th. Cantrips—simple but
-                powerful spells that characters can cast
-                almost by rote—are level 0. The higher a spell’s level, the higher level a spellcaster must be to use
-                that
-                spell.</p>
-            <p>Spell level and character level don’t correspond directly. Typically, a character has to be at least 17th
-                level, not 9th level, to cast a 9th-level spell.</p>
-            <h2>Known and Prepared Spells</h2>
-            <p>Before a spellcaster can use a spell, he or she must have the spell firmly fixed in mind, or must have
-                access
-                to the spell in a magic item. Members of a few classes, including bards and sorcerers, have a limited
-                list of
-                spells they know that are always fixed in mind. The same thing is true of many magic-using monsters.
-                Other
-                spellcasters, such as clerics and wizards, undergo a process of preparing spells. This process varies
-                for
-                different classes, as detailed in their descriptions.</p>
-            <p>In every case, the number of spells a caster can have fixed in mind at any given time depends on the
-                character’s level.</p>
-            <h2>Spell Slots</h2>
-            <p>Regardless of how many spells a caster knows or prepares, he or she can cast only a limited number of
-                spells
-                before resting. Manipulating the fabric of magic and channeling its energy into even a simple spell is
-                physically and mentally taxing, and higherlevel spells are even more so. Thus, each spellcasting class’s
-                description (except that of the warlock) includes a table showing how many spell slots of each spell
-                level a
-                character can use at each character level. For example, the 3rd-level wizard Umara has four 1st-level
-                spell
-                slots and two 2nd-level slots.</p>
-            <p>When a character casts a spell, he or she expends a slot of that spell’s level or higher, effectively
-                “filling”
-                a slot with the spell. You can think of a spell slot as a groove of a certain size—small for a 1st-level
-                slot,
-                larger for a spell of higher level. A 1st-level spell fits into a slot of any size, but a 9th-level
-                spell fits
-                only in a 9th-level slot. So when Umara casts <a class="entity-link" draggable="true"
-                    data-pack="dnd5e.spells" data-id="41JIhpDyM9Anm7cs"><i class="fas fa-suitcase"></i> Magic
-                    Missile</a>, a 1st-level spell, she spends
-                one of her four 1st-level slots and has three remaining.</p>
-            <p>Finishing a long rest restores any expended spell slots.</p>
-            <p>Some characters and monsters have special abilities that let them cast spells without using spell slots.
-                For
-                example, a monk who follows the Way of the Four Elements, a warlock who chooses certain eldritch
-                invocations,
-                and a pit fiend from the Nine Hells can all cast spells in such a way.</p>
-            <h3>Casting a Spell at a Higher Level</h3>
-            <p>When a spellcaster casts a spell using a slot that is of a higher level than the spell, the spell assumes
-                the
-                higher level for that casting. For instance, if Umara casts <a class="entity-link" draggable="true"
-                    data-pack="dnd5e.spells" data-id="41JIhpDyM9Anm7cs"><i class="fas fa-suitcase"></i> Magic
-                    Missile</a><em>
-                </em>using one of her 2nd-level slots, that <em>magic missile </em>is 2nd level. Effectively, the spell
-                expands
-                to fill the slot it is put into.</p>
-            <p>Some spells, such as <em>magic missile </em>and <a class="entity-link" draggable="true"
-                    data-pack="dnd5e.spells" data-id="uUWb1wZgtMou0TVP"><i class="fas fa-suitcase"></i> Cure Wounds</a>,
-                have more
-                powerful effects when cast at a higher level, as detailed in a spell’s description.</p>
-            <hr>
-            <h4>Casting in Armor</h4>
-            <p>Because of the mental focus and precise gestures required for spellcasting, you must be proficient with
-                the
-                armor you are wearing to cast a spell. You are otherwise too distracted and physically hampered by your
-                armor
-                for spellcasting.</p>
-            <hr>
-            <h2>Cantrips</h2>
-            <p>A cantrip is a spell that can be cast at will, without using a spell slot and without being prepared in
-                advance. Repeated practice has fixed the spell in the caster’s mind and infused the caster with the
-                magic needed
-                to produce the effect over and over. A cantrip’s spell level is 0.</p>
-            <h2>Rituals</h2>
-            <p>Certain spells have a special tag: ritual. Such a spell can be cast following the normal rules for
-                spellcasting, or the spell can be cast as a ritual. The ritual version of a spell takes 10 minutes
-                longer to
-                cast than normal. It also doesn’t expend a spell slot, which means the ritual version of a spell can’t
-                be cast
-                at a higher level.</p>
-            <p>To cast a spell as a ritual, a spellcaster must have a feature that grants the ability to do so. The
-                cleric and
-                the druid, for example, have such a feature. The caster must also have the spell prepared or on his or
-                her list
-                of spells known, unless the character’s ritual feature specifies otherwise, as the wizard’s does.</p>
-        </div>
-    </div>
 
-    <button class="step-button" data-back="eqDiv">{{localize 'HTC.Tabs.Back'}}</button>
-    <button class="step-button" data-next="bioDiv">{{localize 'HTC.Tabs.Next'}}</button>
+        <div class="flex-separator">
+            <div style="width: 50%">
+                <form class="flexcol prototype form__select--margin" action="">
+                    <label for="CLASS">CLASS PLACEHOLDER</label>
+                    <select name="" id=""></select>
+                    <select name="" id=""></select>
+                    <select name="" id=""></select>
+                    <select name="" id=""></select>
+                    <label for="CLASS">CLASS PLACEHOLDER</label>
+                    <select name="" id=""></select>
+                    <select name="" id=""></select>
+                    <select name="" id=""></select>
+                    <select name="" id=""></select>
+                </form>
+            </div>
+            <div class="textarea infoArea" style="height: 375px;">
+                <p>A spell is a discrete magical effect, a single shaping of the magical energies that suffuse the
+                    multiverse into
+                    a specific, limited expression. In casting a spell, a character carefully plucks at the invisible
+                    strands of raw
+                    magic suffusing the world, pins them in place in a particular pattern, sets them vibrating in a
+                    specific
+                    way,
+                    and then releases them to unleash the desired effect—in most cases, all in the span of seconds.</p>
+                <p>Spells can be versatile tools, weapons, or protective wards. They can deal damage or undo it, impose
+                    or
+                    remove
+                    conditions (see <a class="entity-link" draggable="true" data-pack="dnd5e.rules"
+                        data-id="lrgT2KMBGTgZD4sA"><i class="fas fa-book-open"></i> Appendix PH-A</a>), drain life
+                    energy
+                    away, and restore life to the dead.</p>
+                <p>Uncounted thousands of spells have been created over the course of the multiverse’s history, and many
+                    of
+                    them
+                    are long forgotten. Some might yet lie recorded in crumbling spellbooks hidden in ancient ruins or
+                    trapped in
+                    the minds of dead gods. Or they might someday be reinvented by a character who has amassed enough
+                    power
+                    and
+                    wisdom to do so.</p>
+                <h2>Spell Level</h2>
+                <p>Every spell has a level from 0 to 9. A spell’s level is a general indicator of how powerful it is,
+                    with
+                    the
+                    lowly (but still impressive) <a class="entity-link" draggable="true" data-pack="dnd5e.spells"
+                        data-id="41JIhpDyM9Anm7cs"><i class="fas fa-suitcase"></i> Magic Missile</a> at 1st level and
+                    the
+                    earth-shaking <a class="entity-link" draggable="true" data-pack="dnd5e.spells"
+                        data-id="3okM6Gn63zzEULkz"><i class="fas fa-suitcase"></i> Wish</a> at 9th. Cantrips—simple but
+                    powerful spells that characters can cast
+                    almost by rote—are level 0. The higher a spell’s level, the higher level a spellcaster must be to
+                    use
+                    that
+                    spell.</p>
+                <p>Spell level and character level don’t correspond directly. Typically, a character has to be at least
+                    17th
+                    level, not 9th level, to cast a 9th-level spell.</p>
+                <h2>Known and Prepared Spells</h2>
+                <p>Before a spellcaster can use a spell, he or she must have the spell firmly fixed in mind, or must
+                    have
+                    access
+                    to the spell in a magic item. Members of a few classes, including bards and sorcerers, have a
+                    limited
+                    list of
+                    spells they know that are always fixed in mind. The same thing is true of many magic-using monsters.
+                    Other
+                    spellcasters, such as clerics and wizards, undergo a process of preparing spells. This process
+                    varies
+                    for
+                    different classes, as detailed in their descriptions.</p>
+                <p>In every case, the number of spells a caster can have fixed in mind at any given time depends on the
+                    character’s level.</p>
+                <h2>Spell Slots</h2>
+                <p>Regardless of how many spells a caster knows or prepares, he or she can cast only a limited number of
+                    spells
+                    before resting. Manipulating the fabric of magic and channeling its energy into even a simple spell
+                    is
+                    physically and mentally taxing, and higherlevel spells are even more so. Thus, each spellcasting
+                    class’s
+                    description (except that of the warlock) includes a table showing how many spell slots of each spell
+                    level a
+                    character can use at each character level. For example, the 3rd-level wizard Umara has four
+                    1st-level
+                    spell
+                    slots and two 2nd-level slots.</p>
+                <p>When a character casts a spell, he or she expends a slot of that spell’s level or higher, effectively
+                    “filling”
+                    a slot with the spell. You can think of a spell slot as a groove of a certain size—small for a
+                    1st-level
+                    slot,
+                    larger for a spell of higher level. A 1st-level spell fits into a slot of any size, but a 9th-level
+                    spell fits
+                    only in a 9th-level slot. So when Umara casts <a class="entity-link" draggable="true"
+                        data-pack="dnd5e.spells" data-id="41JIhpDyM9Anm7cs"><i class="fas fa-suitcase"></i> Magic
+                        Missile</a>, a 1st-level spell, she spends
+                    one of her four 1st-level slots and has three remaining.</p>
+                <p>Finishing a long rest restores any expended spell slots.</p>
+                <p>Some characters and monsters have special abilities that let them cast spells without using spell
+                    slots.
+                    For
+                    example, a monk who follows the Way of the Four Elements, a warlock who chooses certain eldritch
+                    invocations,
+                    and a pit fiend from the Nine Hells can all cast spells in such a way.</p>
+                <h3>Casting a Spell at a Higher Level</h3>
+                <p>When a spellcaster casts a spell using a slot that is of a higher level than the spell, the spell
+                    assumes
+                    the
+                    higher level for that casting. For instance, if Umara casts <a class="entity-link" draggable="true"
+                        data-pack="dnd5e.spells" data-id="41JIhpDyM9Anm7cs"><i class="fas fa-suitcase"></i> Magic
+                        Missile</a><em>
+                    </em>using one of her 2nd-level slots, that <em>magic missile </em>is 2nd level. Effectively, the
+                    spell
+                    expands
+                    to fill the slot it is put into.</p>
+                <p>Some spells, such as <em>magic missile </em>and <a class="entity-link" draggable="true"
+                        data-pack="dnd5e.spells" data-id="uUWb1wZgtMou0TVP"><i class="fas fa-suitcase"></i> Cure
+                        Wounds</a>,
+                    have more
+                    powerful effects when cast at a higher level, as detailed in a spell’s description.</p>
+                <hr>
+                <h4>Casting in Armor</h4>
+                <p>Because of the mental focus and precise gestures required for spellcasting, you must be proficient
+                    with
+                    the
+                    armor you are wearing to cast a spell. You are otherwise too distracted and physically hampered by
+                    your
+                    armor
+                    for spellcasting.</p>
+                <hr>
+                <h2>Cantrips</h2>
+                <p>A cantrip is a spell that can be cast at will, without using a spell slot and without being prepared
+                    in
+                    advance. Repeated practice has fixed the spell in the caster’s mind and infused the caster with the
+                    magic needed
+                    to produce the effect over and over. A cantrip’s spell level is 0.</p>
+                <h2>Rituals</h2>
+                <p>Certain spells have a special tag: ritual. Such a spell can be cast following the normal rules for
+                    spellcasting, or the spell can be cast as a ritual. The ritual version of a spell takes 10 minutes
+                    longer to
+                    cast than normal. It also doesn’t expend a spell slot, which means the ritual version of a spell
+                    can’t
+                    be cast
+                    at a higher level.</p>
+                <p>To cast a spell as a ritual, a spellcaster must have a feature that grants the ability to do so. The
+                    cleric and
+                    the druid, for example, have such a feature. The caster must also have the spell prepared or on his
+                    or
+                    her list
+                    of spells known, unless the character’s ritual feature specifies otherwise, as the wizard’s does.
+                </p>
+            </div>
+        </div>
+    </main>
+
+    <footer class='tab-footer'>
+        <button class="step-button" data-hct_back="eqDiv">{{localize 'HTC.Tabs.Back'}}</button>
+        <button class="step-button" data-hct_next="bioDiv">{{localize 'HTC.Tabs.Next'}}</button>
+    </footer>
 </div>

--- a/templates/tabs/start.html
+++ b/templates/tabs/start.html
@@ -1,17 +1,18 @@
-<div id="startDiv" class="tabcontent apply-header-font">
-  <h1>{{localize 'HTC.Tabs.Start.Welcome'}}</h1>
+<div id="startDiv" class="tab-body apply-header-font">
+  <h1 class='tab-header'>{{localize 'HTC.Tabs.Start.Welcome'}}</h1>
 
-  <section>
+  <main class='tab-content'>
     {{localize 'HTC.Tabs.Start.p1'}}
     <br><br>
     {{localize 'HTC.Tabs.Start.p2'}}
     <br><br>
-    <b>{{localize 'HTC.Tabs.Start.Remark'}}</b>
+    <b class="centered-text">{{localize 'HTC.Tabs.Start.Remark'}}</b>
     <br>
-    <img src="https://i.imgur.com/UoQolQ2.png" style=" width: 50%; margin-left: auto;
-      margin-right: auto; display: block; border: none">
+    <img id="main-logo">
     <br>
-  </section>
+  </main>
 
-  <button class="step-button" data-next='basicsDiv'>{{localize 'HTC.Tabs.Next'}}</button>
+  <footer class='tab-footer'>
+    <button class="step-button" data-hct_next='basicsDiv'>{{localize 'HTC.Tabs.Next'}}</button>
+  </footer>
 </div>


### PR DESCRIPTION
* Fixed CSS after Le Big Refactoring
* Replaced window references with globalThis (you can read about globalThis [HERE](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis))
* Logo image from start tab included into /assets folder and imported on the css (so we don't need to open the logo from imgur anymore, and the module shows the logo even when playing offline - also serves as a working example if we need to add more images elsewhere)

Example screenshot with new fixed CSS (buttons aligned on the center, with look-and-feel like vanilla fvtt buttons; buttons always present on bottom; content in tabs scrollable as needed)
![image](https://user-images.githubusercontent.com/4467128/114984399-986e3680-9e89-11eb-8de4-e1d6da22d656.png)

**PENDING**:
* The Abilities "Info" button could use some love probably, I will see if I can improve it later.